### PR TITLE
Add CMake build support for theWheelView and theWheel MFC application

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,9 +54,13 @@ add_subdirectory ("theWheelModel")
 
 if(MSVC)
     add_subdirectory ("pybind")
+    add_subdirectory ("theWheelView")
+    add_subdirectory ("theWheel")
 endif()
 
-add_subdirectory ("OptimizeND")
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/OptimizeND")
+    add_subdirectory ("OptimizeND")
+endif()
 add_subdirectory ("theWheelModelTests")
 
 # wxWidgets application (macOS/Linux)

--- a/src/theWheel/CMakeLists.txt
+++ b/src/theWheel/CMakeLists.txt
@@ -1,0 +1,83 @@
+# CMakeLists.txt for theWheel MFC application (Windows only)
+
+if(NOT MSVC)
+    return()
+endif()
+
+# Source files
+set(THEWHEEL_SOURCES
+    ImagePropDlg.cpp
+    LeftView.cpp
+    LinkPropDlg.cpp
+    MainFrm.cpp
+    NodePropDlg.cpp
+    spaceclassdlg.cpp
+    spaceoptdlg.cpp
+    spacepropdlg.cpp
+    SpaceTreeView.cpp
+    stdafx.cpp
+    theWheel.cpp
+    theWheelDoc.cpp
+    theWheelView.cpp
+    TreeMenuCtrl.cpp
+)
+
+# Header files
+set(THEWHEEL_HEADERS
+    imagepropdlg.h
+    LeftView.h
+    linkpropdlg.h
+    MainFrm.h
+    NodePropDlg.h
+    Resource.h
+    spaceclassdlg.h
+    spaceoptdlg.h
+    spacepropdlg.h
+    SpaceTreeView.h
+    stdafx.h
+    theWheel.h
+    theWheelDoc.h
+    theWheelView.h
+    TreeMenuCtrl.h
+)
+
+# Resource file
+set(THEWHEEL_RESOURCES
+    theWheel.rc
+)
+
+# MFC application (WIN32 = Windows subsystem, not console)
+add_executable(theWheelApp WIN32
+    ${THEWHEEL_SOURCES}
+    ${THEWHEEL_HEADERS}
+    ${THEWHEEL_RESOURCES}
+)
+
+# Use dynamic MFC
+set(CMAKE_MFC_FLAG 2)
+set_target_properties(theWheelApp PROPERTIES
+    COMPILE_DEFINITIONS "_AFXDLL"
+    OUTPUT_NAME "theWheel"
+)
+
+# Include directories
+target_include_directories(theWheelApp
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+# Link dependencies
+target_link_libraries(theWheelApp
+    PRIVATE
+        theWheelView
+        theWheelModel
+        OptimizeN
+        d3d9.lib
+        ddraw.lib
+        dsound.lib
+        dxguid.lib
+        winmm.lib
+)
+
+# Precompiled headers
+target_precompile_headers(theWheelApp PRIVATE stdafx.h)

--- a/src/theWheel/SpaceTreeView.cpp
+++ b/src/theWheel/SpaceTreeView.cpp
@@ -720,7 +720,7 @@ void CSpaceTreeView::OnLButtonUp(UINT nFlags, CPoint point)
 // 
 // scrolling during drag
 //////////////////////////////////////////////////////////////////////
-void CSpaceTreeView::OnTimer(UINT nIDEvent) 
+void CSpaceTreeView::OnTimer(UINT_PTR nIDEvent)
 {
     // check the ID to see if it is the scrolling timer
     if (nIDEvent != m_nScrollTimerID)

--- a/src/theWheel/SpaceTreeView.h
+++ b/src/theWheel/SpaceTreeView.h
@@ -97,7 +97,7 @@ protected:
 	afx_msg void OnBeginDrag(NMHDR* pNMHDR, LRESULT* pResult);
 	afx_msg void OnMouseMove(UINT nFlags, CPoint point);
 	afx_msg void OnLButtonUp(UINT nFlags, CPoint point);
-	afx_msg void OnTimer(UINT nIDEvent);
+	afx_msg void OnTimer(UINT_PTR nIDEvent);
 	afx_msg void OnSpaceTabChanged(NMHDR* pNMHDR, LRESULT* pResult);
 	afx_msg void OnNodeTabChanged(NMHDR* pNMHDR, LRESULT* pResult);
 	afx_msg void OnNewNode();

--- a/src/theWheelView/CMakeLists.txt
+++ b/src/theWheelView/CMakeLists.txt
@@ -1,0 +1,76 @@
+# CMakeLists.txt for theWheelView library (Windows/DirectX only)
+
+if(NOT MSVC)
+    return()
+endif()
+
+# DirectX 9 headers and libraries ship with the Windows 10 SDK.
+# The legacy June 2010 DirectX SDK is not required.
+
+# Source files
+set(THEWHEELVIEW_SOURCES
+    DesigntimeTracker.cpp
+    Elliptangle.cpp
+    Molding.cpp
+    NodeLayoutManager.cpp
+    NodeView.cpp
+    NodeViewSkin.cpp
+    NodeViewSkin2007.cpp
+    Plaque.cpp
+    RadialShape.cpp
+    RuntimeTracker.cpp
+    SpaceView.cpp
+    Spring.cpp
+    stdafx.cpp
+    Tracker.cpp
+)
+
+# Header files
+set(THEWHEELVIEW_HEADERS
+    include/DesigntimeTracker.h
+    include/Elliptangle.h
+    include/Extent.h
+    include/Molding.h
+    include/NodeLayoutManager.h
+    include/NodeView.h
+    include/NodeViewSkin.h
+    include/NodeViewSkin2007.h
+    include/Plaque.h
+    include/RadialShape.h
+    include/RuntimeTracker.h
+    include/SpaceView.h
+    include/Spring.h
+    include/Tracker.h
+    D3DXImpl.h
+    THEWHEEL_VIEW_resource.h
+    stdafx.h
+)
+
+# Create static library
+add_library(theWheelView STATIC ${THEWHEELVIEW_SOURCES} ${THEWHEELVIEW_HEADERS})
+
+# Include directories
+target_include_directories(theWheelView
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+# Link dependencies
+target_link_libraries(theWheelView
+    PUBLIC
+        theWheelModel
+        OptimizeN
+    PRIVATE
+        d3d9.lib
+        dxguid.lib
+        winmm.lib
+)
+
+# MFC in shared DLL
+set_target_properties(theWheelView PROPERTIES
+    COMPILE_DEFINITIONS "_AFXDLL"
+)
+
+# Precompiled headers
+target_precompile_headers(theWheelView PRIVATE stdafx.h)

--- a/src/theWheelView/RuntimeTracker.cpp
+++ b/src/theWheelView/RuntimeTracker.cpp
@@ -239,7 +239,9 @@ HRESULT CRuntimeTracker::OpenUrl(const CString &strUrl)
 
 	// and send to the top
 	HWND hWnd = NULL;
-	CHECK_HRESULT(m_pBrowser->get_HWND((long *) &hWnd));
+	SHANDLE_PTR hWndPtr = 0;
+	CHECK_HRESULT(m_pBrowser->get_HWND(&hWndPtr));
+	hWnd = (HWND)hWndPtr;
 	::SetWindowPos(hWnd, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
 
 	return S_OK;

--- a/src/theWheelView/SpaceView.cpp
+++ b/src/theWheelView/SpaceView.cpp
@@ -1175,7 +1175,7 @@ void CSpaceView::OnLButtonDblClk(UINT nFlags, CPoint point)
 // 
 // Timer call updates the springs and performs a layout
 //////////////////////////////////////////////////////////////////////
-void CSpaceView::OnTimer(UINT nIDEvent) 
+void CSpaceView::OnTimer(UINT_PTR nIDEvent)
 {
 	// AFX_MANAGE_STATE(m_pModuleState);
 

--- a/src/theWheelView/include/SpaceView.h
+++ b/src/theWheelView/include/SpaceView.h
@@ -125,7 +125,7 @@ protected:
 	afx_msg void OnMouseMove(UINT nFlags, CPoint point);
 	afx_msg void OnLButtonDown(UINT nFlags, CPoint point);
 	afx_msg void OnLButtonUp(UINT nFlags, CPoint point);
-	afx_msg void OnTimer(UINT nIDEvent);
+	afx_msg void OnTimer(UINT_PTR nIDEvent);
 	afx_msg void OnKeyDown(UINT nChar, UINT nRepCnt, UINT nFlags);
 	afx_msg void OnLButtonDblClk(UINT nFlags, CPoint point);
 	//}}AFX_MSG


### PR DESCRIPTION
Creates CMakeLists.txt for theWheelView (static library) and theWheel (MFC executable), integrating them into the existing CMake build system. Also fixes x64 compilation issues (UINT vs UINT_PTR for OnTimer, and SHANDLE_PTR for get_HWND) and guards missing OptimizeND directory.