### PR TITLE
Add OpenGL ES renderer via ANGLE, replacing D3D9 fixed-function pipeline

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -11,6 +11,12 @@
                 "type": "equals",
                 "lhs": "${hostSystemName}",
                 "rhs": "Windows"
+            },
+            "cacheVariables": {
+                "CMAKE_TOOLCHAIN_FILE": {
+                    "type": "FILEPATH",
+                    "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+                }
             }
         },
         {
@@ -72,7 +78,11 @@
                 "rhs": "Darwin"
             },
             "cacheVariables": {
-                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "CMAKE_TOOLCHAIN_FILE": {
+                    "type": "FILEPATH",
+                    "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+                }
             }
         },
         {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,9 @@ enable_testing()
 add_subdirectory ("OptimizeN")
 add_subdirectory ("theWheelModel")
 
+# Cross-platform OpenGL ES renderer (via ANGLE)
+add_subdirectory ("theWheelGL")
+
 if(MSVC)
     add_subdirectory ("pybind")
     add_subdirectory ("theWheelView")

--- a/src/theWheelGL/CMakeLists.txt
+++ b/src/theWheelGL/CMakeLists.txt
@@ -1,0 +1,91 @@
+# CMakeLists.txt for theWheelGL — cross-platform OpenGL ES renderer via ANGLE
+
+# Source files
+set(THEWHEELGL_SOURCES
+    GLRenderer.cpp
+    GLPlaque.cpp
+    GLNodeViewSkin.cpp
+    GLNodeView.cpp
+    # Geometry source files wrapped with our own StdAfx.h shim
+    GeometryWrappers.cpp
+)
+
+# Header files
+set(THEWHEELGL_HEADERS
+    include/GLRenderer.h
+    include/GLPlaque.h
+    include/GLNodeViewSkin.h
+    include/GLNodeView.h
+    include/GLMath.h
+    Shaders.h
+)
+
+# Create static library
+add_library(theWheelGL STATIC ${THEWHEELGL_SOURCES} ${THEWHEELGL_HEADERS})
+
+# Include directories
+target_include_directories(theWheelGL
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+# Depend on theWheelModel and OptimizeN for CNode, CExtent, CVectorD, etc.
+target_link_libraries(theWheelGL
+    PUBLIC
+        theWheelModel
+        OptimizeN
+)
+
+# ANGLE via vcpkg
+find_package(unofficial-angle CONFIG)
+if(unofficial-angle_FOUND)
+    target_link_libraries(theWheelGL
+        PUBLIC
+            unofficial::angle::libEGL
+            unofficial::angle::libGLESv2
+    )
+    # ANGLE's CMake targets may not export INTERFACE_INCLUDE_DIRECTORIES;
+    # add the vcpkg installed headers path explicitly.
+    if(VCPKG_INSTALLED_DIR)
+        target_include_directories(theWheelGL PUBLIC
+            "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include")
+    endif()
+    message(STATUS "theWheelGL: using ANGLE from vcpkg")
+else()
+    # Fallback: try to find system EGL/GLES2 (e.g., on Linux/macOS with native GL)
+    find_package(OpenGL)
+    if(OpenGL_EGL_FOUND AND OpenGL_GLESv2_FOUND)
+        target_link_libraries(theWheelGL PUBLIC OpenGL::EGL OpenGL::GLESv2)
+        message(STATUS "theWheelGL: using system EGL/GLESv2")
+    else()
+        message(WARNING "theWheelGL: neither ANGLE nor system EGL/GLESv2 found — "
+                        "install ANGLE via vcpkg or provide EGL/GLESv2")
+    endif()
+endif()
+
+# theWheelGL needs RadialShape/Elliptangle headers from theWheelView.
+# Rather than moving those files now, just add theWheelView's include dir.
+# On non-MSVC builds (macOS) theWheelView doesn't exist, so use the source path directly.
+target_include_directories(theWheelGL
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../theWheelView/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/../theWheelView
+)
+
+# Set C++ standard
+target_compile_features(theWheelGL PRIVATE cxx_std_17)
+
+# Force-include StdAfx.h shim to provide REAL, CVectorD, CExtent, ASSERT, RECT
+# for all source files (needed by RadialShape.h and other theWheelView headers).
+if(MSVC)
+    target_compile_options(theWheelGL PRIVATE /FI"${CMAKE_CURRENT_SOURCE_DIR}/StdAfx.h")
+else()
+    target_compile_options(theWheelGL PRIVATE
+        -include "${CMAKE_CURRENT_SOURCE_DIR}/StdAfx.h")
+    # The wxcompat.h provides mfc_compat stubs needed by theWheelModel headers
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../theWheelWx/wxcompat.h")
+        target_compile_options(theWheelGL PRIVATE
+            -include "${CMAKE_CURRENT_SOURCE_DIR}/../theWheelWx/wxcompat.h")
+    endif()
+endif()

--- a/src/theWheelGL/GLNodeView.cpp
+++ b/src/theWheelGL/GLNodeView.cpp
@@ -1,0 +1,85 @@
+/// GLNodeView.cpp
+/// Implementation of GLNodeView static rendering helpers.
+///
+/// Copyright (C) 1996-2007 Derek G Lane
+
+#include "GLNodeView.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace theWheelGL {
+
+GLuint GLNodeView::s_linkVBO = 0;
+
+void GLNodeView::Draw(GLRenderer& renderer, GLNodeViewSkin& skin,
+                      float centerX, float centerY, float centerZ,
+                      float activation)
+{
+    skin.Render(renderer, activation, centerX, centerY, centerZ);
+}
+
+void GLNodeView::ensureLinkVBO()
+{
+    if (s_linkVBO == 0) {
+        // A simple 2-vertex line buffer; positions set per-draw via buffer sub-data
+        float lineVerts[12] = {
+            0, 0, 0, 0, 0, 1,  // vertex 0: pos + normal
+            0, 0, 0, 0, 0, 1   // vertex 1: pos + normal
+        };
+        glGenBuffers(1, &s_linkVBO);
+        glBindBuffer(GL_ARRAY_BUFFER, s_linkVBO);
+        glBufferData(GL_ARRAY_BUFFER, sizeof(lineVerts), lineVerts, GL_DYNAMIC_DRAW);
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
+    }
+}
+
+void GLNodeView::DrawLink(GLRenderer& renderer,
+                           float fromX, float fromY, float fromZ,
+                           float toX, float toY, float toZ,
+                           float fromAct, float toAct)
+{
+    float totalAct = fromAct + toAct;
+    if (totalAct < 0.04f)
+        return;
+
+    ensureLinkVBO();
+
+    // Update link vertices
+    float verts[12] = {
+        fromX, fromY, fromZ, 0, 0, 1,
+        toX,   toY,   toZ,   0, 0, 1
+    };
+
+    glBindBuffer(GL_ARRAY_BUFFER, s_linkVBO);
+    glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(verts), verts);
+
+    GLint aPos = renderer.GetPositionAttrib();
+    GLint aNorm = renderer.GetNormalAttrib();
+
+    glEnableVertexAttribArray(aPos);
+    glVertexAttribPointer(aPos, 3, GL_FLOAT, GL_FALSE, 6 * sizeof(float), (void*)0);
+    glEnableVertexAttribArray(aNorm);
+    glVertexAttribPointer(aNorm, 3, GL_FLOAT, GL_FALSE, 6 * sizeof(float), (void*)(3 * sizeof(float)));
+
+    // Set link material color — darker shade of background
+    float shade = 0.85f;
+    if (totalAct < 0.06f) shade = 0.95f;
+    else if (totalAct < 0.08f) shade = 0.90f;
+
+    renderer.SetMaterial(shade, shade, shade, 1.0f, shade, shade, shade);
+    renderer.SetWorldMatrix(Mat4f()); // identity
+    renderer.ApplyUniforms();
+
+    // Line width based on activation (clamped to GL limits)
+    float lineW = 1.0f + std::sqrt(totalAct) * 4.0f;
+    lineW = std::min(lineW, 5.0f);
+    glLineWidth(lineW);
+
+    glDrawArrays(GL_LINES, 0, 2);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glLineWidth(1.0f);
+}
+
+} // namespace theWheelGL

--- a/src/theWheelGL/GLNodeViewSkin.cpp
+++ b/src/theWheelGL/GLNodeViewSkin.cpp
@@ -1,0 +1,105 @@
+/// GLNodeViewSkin.cpp
+/// Implementation of GLNodeViewSkin — port of NodeViewSkin2007.
+///
+/// Copyright (C) 1996-2007 Derek G Lane
+
+#include "GLNodeViewSkin.h"
+#include "Elliptangle.h"
+
+#include <cmath>
+#include <algorithm>
+
+namespace theWheelGL {
+
+// Constants matching NodeViewSkin2007.cpp
+static const float BORDER_RADIUS = 2.0f;
+static const float RECT_SIZE_MAX = 13.0f / 16.0f;
+static const float RECT_SIZE_SCALE = 6.0f / 16.0f;
+
+static float computeEllipticalness(float activation)
+{
+    float scale = 1.0f - 1.0f / std::sqrt(2.0f);
+    return 1.0f - scale * std::exp(-1.5f * activation + 0.01f);
+}
+
+GLNodeViewSkin::GLNodeViewSkin()
+{
+}
+
+GLNodeViewSkin::~GLNodeViewSkin()
+{
+    for (auto p : m_plaques)
+        delete p;
+}
+
+void GLNodeViewSkin::CalcRectForActivation(float activation, float& outW, float& outH)
+{
+    float aspectRatio = RECT_SIZE_MAX - RECT_SIZE_SCALE * std::exp(-2.0f * activation);
+    outW = std::sqrt(activation / aspectRatio);
+    outH = std::sqrt(activation * aspectRatio);
+}
+
+int GLNodeViewSkin::getPlaqueIndex(float activation)
+{
+    int index = (int)std::round(activation * 200.0f);
+    index = std::max(index, 1);
+
+    if (index >= (int)m_plaques.size()) {
+        m_plaques.resize(index + 1, nullptr);
+    }
+
+    if (!m_plaques[index]) {
+        float indexActivation = (float)index / 100.0f;
+
+        // Build the elliptangle shape
+        float w, h;
+        CalcRectForActivation(indexActivation, w, h);
+
+        CExtent<2, REAL> rectInner;
+        rectInner.Deflate(-w, -h, -w, -h);
+
+        float ellipt = computeEllipticalness(indexActivation);
+        auto* pElliptangle = new theWheel2007::Elliptangle(rectInner, ellipt);
+
+        float borderRadius = BORDER_RADIUS;
+        if (rectInner.GetSize(1) < borderRadius * 4.0f) {
+            borderRadius = (float)rectInner.GetSize(1) / 4.0f;
+        }
+
+        m_plaques[index] = new GLPlaque(pElliptangle, borderRadius);
+    }
+
+    return index;
+}
+
+void GLNodeViewSkin::Render(GLRenderer& renderer, float activation,
+                            float centerX, float centerY, float centerZ)
+{
+    int index = getPlaqueIndex(activation);
+    GLPlaque* plaque = m_plaques[index];
+    if (!plaque) return;
+
+    // Compute scaling (matching NodeViewSkin2007::Render)
+    float w, h;
+    CalcRectForActivation(activation, w, h);
+
+    float sizeUp = 100.0f + 1200.0f * activation * activation;
+
+    auto* shape = plaque->GetShape();
+    float shapeW = (float)shape->InnerRect.GetSize(0);
+    float shapeH = (float)shape->InnerRect.GetSize(1);
+
+    float scaleX = (shapeW > 0.0f) ? sizeUp * w / shapeW : 1.0f;
+    float scaleY = (shapeH > 0.0f) ? sizeUp * h / shapeH : 1.0f;
+    float scaleZ = (scaleX + scaleY) / 2.0f;
+
+    // Build world matrix: translate to node center, then scale plaque
+    Mat4f translate = Mat4f::Translation(-centerX, -centerY, centerZ);
+    Mat4f scale = Mat4f::Scaling(scaleX, scaleY, scaleZ);
+    Mat4f world = translate * scale;
+
+    renderer.SetWorldMatrix(world);
+    plaque->Render(renderer);
+}
+
+} // namespace theWheelGL

--- a/src/theWheelGL/GLPlaque.cpp
+++ b/src/theWheelGL/GLPlaque.cpp
@@ -1,0 +1,294 @@
+/// GLPlaque.cpp
+/// Implementation of the GLPlaque class.
+/// Port of D3D9 Plaque.cpp geometry generation to OpenGL ES VBOs.
+///
+/// Copyright (C) 1996-2007 Derek G Lane
+
+#include "GLPlaque.h"
+#include "RadialShape.h"
+
+#include <cmath>
+
+#ifndef PIf
+#define PIf 3.14159265358979323846f
+#endif
+
+namespace theWheelGL {
+
+GLPlaque::GLPlaque(theWheel2007::RadialShape* pShape, float borderRadius)
+    : m_pShape(pShape)
+    , m_borderRadius(borderRadius)
+    , m_numSteps(8)
+    , m_vertPerSection(0)
+    , m_stripVBO(0)
+    , m_stripIBO(0)
+    , m_faceVBO(0)
+    , m_faceIBO(0)
+    , m_built(false)
+{
+}
+
+GLPlaque::~GLPlaque()
+{
+    if (m_stripVBO) glDeleteBuffers(1, &m_stripVBO);
+    if (m_stripIBO) glDeleteBuffers(1, &m_stripIBO);
+    if (m_faceVBO) glDeleteBuffers(1, &m_faceVBO);
+    if (m_faceIBO) glDeleteBuffers(1, &m_faceIBO);
+    delete m_pShape;
+}
+
+void GLPlaque::Render(GLRenderer& renderer)
+{
+    if (!m_built) {
+        buildGeometry();
+        uploadBuffers();
+        m_built = true;
+    }
+
+    GLint aPos = renderer.GetPositionAttrib();
+    GLint aNorm = renderer.GetNormalAttrib();
+    const GLsizei stride = sizeof(Vertex);
+
+    // --- Draw bevel strip sections ---
+    if (m_stripVBO && m_stripIBO && m_sectionStarts.size() > 1) {
+        glBindBuffer(GL_ARRAY_BUFFER, m_stripVBO);
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_stripIBO);
+
+        glEnableVertexAttribArray(aPos);
+        glVertexAttribPointer(aPos, 3, GL_FLOAT, GL_FALSE, stride, (void*)0);
+        glEnableVertexAttribArray(aNorm);
+        glVertexAttribPointer(aNorm, 3, GL_FLOAT, GL_FALSE, stride, (void*)(3 * sizeof(float)));
+
+        // Set bevel material (light blue-gray, matching D3D9 Plaque::Render)
+        renderer.SetMaterial(0.8f, 0.8f, 0.9f, 1.0f, 0.8f, 0.8f, 0.9f);
+        renderer.ApplyUniforms();
+
+        // Each section pair draws the same index pattern with different base vertex.
+        // In GLES2, we cannot use glDrawElementsBaseVertex, so we generated
+        // absolute indices for each section pair.
+        int indicesPerPair = (int)m_stripIndices.size() / ((int)m_sectionStarts.size() - 1);
+        for (size_t i = 0; i + 1 < m_sectionStarts.size(); i++) {
+            int indexOffset = (int)i * indicesPerPair;
+            glDrawElements(GL_TRIANGLE_STRIP, indicesPerPair, GL_UNSIGNED_SHORT,
+                           (void*)(indexOffset * sizeof(unsigned short)));
+        }
+    }
+
+    // --- Draw center face ---
+    if (m_faceVBO && m_faceIBO) {
+        glBindBuffer(GL_ARRAY_BUFFER, m_faceVBO);
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_faceIBO);
+
+        glEnableVertexAttribArray(aPos);
+        glVertexAttribPointer(aPos, 3, GL_FLOAT, GL_FALSE, stride, (void*)0);
+        glEnableVertexAttribArray(aNorm);
+        glVertexAttribPointer(aNorm, 3, GL_FLOAT, GL_FALSE, stride, (void*)(3 * sizeof(float)));
+
+        // Set face material (warm red-brown, matching D3D9 Plaque::Render)
+        renderer.SetMaterial(0.7f, 0.4f, 0.4f, 1.0f, 0.7f, 0.4f, 0.4f);
+        renderer.ApplyUniforms();
+
+        glDrawElements(GL_TRIANGLES, (GLsizei)m_faceIndices.size(),
+                       GL_UNSIGNED_SHORT, (void*)0);
+    }
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+}
+
+void GLPlaque::buildGeometry()
+{
+    m_stripVerts.clear();
+    m_sectionStarts.clear();
+    calcSections(m_stripVerts);
+    buildStripIndices();
+    buildFanGeometry();
+}
+
+void GLPlaque::calcSections(std::vector<Vertex>& verts)
+{
+    auto& arrDiscont = m_pShape->Discontinuities();
+    size_t nNextDiscont = 0;
+
+    const float step = 2.0f * PIf / (float)(m_numSteps * 4);
+
+    float theta = 0.0f;
+    for (int nSlice = 0; nSlice < m_numSteps * 4; nSlice++) {
+        if (nSlice + 1 == m_numSteps * 4) {
+            theta = 0.0f; // close the loop
+        }
+
+        CVectorD<2, REAL> vPt = m_pShape->Eval(theta);
+        m_sectionStarts.push_back((int)verts.size());
+        calcVertsForSection(theta, Vec3f((float)vPt[0], (float)vPt[1], 0.0f), verts);
+
+        theta += step;
+
+        if (nNextDiscont < arrDiscont.size() && theta > arrDiscont[nNextDiscont]) {
+            theta = (float)arrDiscont[nNextDiscont++];
+            nSlice--; // extra slice at discontinuity
+        }
+    }
+}
+
+void GLPlaque::calcVertsForSection(float theta, const Vec3f& offset,
+                                   std::vector<Vertex>& verts)
+{
+    int origLen = (int)verts.size();
+    Mat4f mRotate = Mat4f::RotationZ(theta);
+
+    const float step = (PIf / 2.0f) / (float)(m_numSteps - 1);
+
+    float angle = 0.0f;
+    for (int nAt = 0; nAt < m_numSteps; nAt++) {
+        Vec3f pos(std::cos(angle), 0.0f, std::sin(angle));
+        Vec3f normal = mRotate.transformNormal(pos);
+        Vec3f tpos = mRotate.transformCoord(pos);
+        tpos *= m_borderRadius;
+        tpos += offset;
+
+        Vertex v;
+        v.px = tpos.x; v.py = tpos.y; v.pz = tpos.z;
+        v.nx = normal.x; v.ny = normal.y; v.nz = normal.z;
+        verts.push_back(v);
+
+        angle += step;
+    }
+
+    // Pie-wedge tip vertex
+    Vertex tipVert;
+    tipVert.px = offset.x; tipVert.py = offset.y; tipVert.pz = m_borderRadius;
+    // Reuse last normal for the tip
+    if (!verts.empty()) {
+        auto& last = verts.back();
+        tipVert.nx = last.nx; tipVert.ny = last.ny; tipVert.nz = last.nz;
+    } else {
+        tipVert.nx = 0; tipVert.ny = 0; tipVert.nz = 1.0f;
+    }
+    verts.push_back(tipVert);
+
+    m_vertPerSection = (int)verts.size() - origLen;
+}
+
+void GLPlaque::buildStripIndices()
+{
+    m_stripIndices.clear();
+
+    if (m_sectionStarts.size() < 2)
+        return;
+
+    // For each adjacent section pair, create a triangle strip
+    for (size_t s = 0; s + 1 < m_sectionStarts.size(); s++) {
+        int base0 = m_sectionStarts[s];
+        int base1 = m_sectionStarts[s + 1];
+
+        // Bevel surface: interleave vertices from section s and s+1
+        for (int nAt = 0; nAt < m_numSteps - 1; nAt++) {
+            m_stripIndices.push_back((unsigned short)(base0 + nAt));
+            m_stripIndices.push_back((unsigned short)(base1 + nAt));
+            m_stripIndices.push_back((unsigned short)(base0 + nAt + 1));
+            m_stripIndices.push_back((unsigned short)(base1 + nAt + 1));
+        }
+
+        // Pie-wedge fill to interior
+        m_stripIndices.push_back((unsigned short)(base0 + m_numSteps - 1));
+        m_stripIndices.push_back((unsigned short)(base1 + m_numSteps - 1));
+        // Tip vertex (last vertex in each section)
+        m_stripIndices.push_back((unsigned short)(base1 + m_numSteps));
+    }
+}
+
+void GLPlaque::buildFanGeometry()
+{
+    m_faceVerts.clear();
+    m_faceIndices.clear();
+
+    auto& arrDiscont = m_pShape->Discontinuities();
+    size_t nNextDiscont = 0;
+
+    // Calculate Y position for the face (matches D3D9 fan)
+    float Y = (float)(m_pShape->InnerRect.GetMin(1)
+                      + m_pShape->InnerRect.GetSize(1) * 0.75f);
+    float angleStart = 0.0f, angleEnd = PIf;
+    m_pShape->InvEvalY(Y, angleStart, angleEnd);
+
+    // Center vertex
+    Vertex center;
+    center.px = 0.0f; center.py = Y; center.pz = m_borderRadius + 0.1f;
+    center.nx = 0.0f; center.ny = 0.0f; center.nz = 1.0f;
+    m_faceVerts.push_back(center);
+
+    // Edge vertices
+    float angleDiff = angleEnd - angleStart;
+    float curAngle = angleStart;
+    for (int n = 0; n <= m_numSteps * 4; n++) {
+        CVectorD<2, REAL> vPt = m_pShape->Eval(curAngle);
+        Vertex v;
+        v.px = (float)vPt[0]; v.py = (float)vPt[1]; v.pz = m_borderRadius - 0.1f;
+        v.nx = 0.0f; v.ny = 0.0f; v.nz = 1.0f;
+        m_faceVerts.push_back(v);
+
+        curAngle += angleDiff / (float)(m_numSteps * 4);
+
+        // Extra vertex at discontinuity
+        if (nNextDiscont < arrDiscont.size() && curAngle > arrDiscont[nNextDiscont]) {
+            CVectorD<2, REAL> vPtD = m_pShape->Eval(arrDiscont[nNextDiscont++]);
+            Vertex vd;
+            vd.px = (float)vPtD[0]; vd.py = (float)vPtD[1]; vd.pz = m_borderRadius - 0.1f;
+            vd.nx = 0.0f; vd.ny = 0.0f; vd.nz = 1.0f;
+            m_faceVerts.push_back(vd);
+        }
+    }
+
+    // Convert fan (center + N edge verts) to triangles
+    int numEdge = (int)m_faceVerts.size() - 1;
+    for (int i = 0; i < numEdge - 1; i++) {
+        m_faceIndices.push_back(0);                          // center
+        m_faceIndices.push_back((unsigned short)(i + 1));    // edge i
+        m_faceIndices.push_back((unsigned short)(i + 2));    // edge i+1
+    }
+}
+
+void GLPlaque::uploadBuffers()
+{
+    // Strip VBO
+    if (!m_stripVerts.empty()) {
+        glGenBuffers(1, &m_stripVBO);
+        glBindBuffer(GL_ARRAY_BUFFER, m_stripVBO);
+        glBufferData(GL_ARRAY_BUFFER,
+                     m_stripVerts.size() * sizeof(Vertex),
+                     m_stripVerts.data(), GL_STATIC_DRAW);
+    }
+
+    // Strip IBO
+    if (!m_stripIndices.empty()) {
+        glGenBuffers(1, &m_stripIBO);
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_stripIBO);
+        glBufferData(GL_ELEMENT_ARRAY_BUFFER,
+                     m_stripIndices.size() * sizeof(unsigned short),
+                     m_stripIndices.data(), GL_STATIC_DRAW);
+    }
+
+    // Face VBO
+    if (!m_faceVerts.empty()) {
+        glGenBuffers(1, &m_faceVBO);
+        glBindBuffer(GL_ARRAY_BUFFER, m_faceVBO);
+        glBufferData(GL_ARRAY_BUFFER,
+                     m_faceVerts.size() * sizeof(Vertex),
+                     m_faceVerts.data(), GL_STATIC_DRAW);
+    }
+
+    // Face IBO
+    if (!m_faceIndices.empty()) {
+        glGenBuffers(1, &m_faceIBO);
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_faceIBO);
+        glBufferData(GL_ELEMENT_ARRAY_BUFFER,
+                     m_faceIndices.size() * sizeof(unsigned short),
+                     m_faceIndices.data(), GL_STATIC_DRAW);
+    }
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+}
+
+} // namespace theWheelGL

--- a/src/theWheelGL/GLRenderer.cpp
+++ b/src/theWheelGL/GLRenderer.cpp
@@ -1,0 +1,254 @@
+/// GLRenderer.cpp
+/// Implementation of the GLRenderer class.
+///
+/// Copyright (C) 1996-2007 Derek G Lane
+
+#include "GLRenderer.h"
+#include "../Shaders.h"
+
+#include <cstring>
+#include <cstdio>
+
+namespace theWheelGL {
+
+GLRenderer::GLRenderer()
+    : m_display(EGL_NO_DISPLAY)
+    , m_surface(EGL_NO_SURFACE)
+    , m_context(EGL_NO_CONTEXT)
+    , m_width(0)
+    , m_height(0)
+    , m_program(0)
+    , m_aPosition(-1)
+    , m_aNormal(-1)
+    , m_uWorld(-1)
+    , m_uView(-1)
+    , m_uProj(-1)
+    , m_uLightDir(-1)
+    , m_uLightColor(-1)
+    , m_uAmbientColor(-1)
+    , m_uMaterialDiffuse(-1)
+    , m_uMaterialAmbient(-1)
+{
+    m_lightDir = Vec3f(0.0f, 0.0f, -1.0f);
+    m_lightColor = Vec3f(1.0f, 1.0f, 1.0f);
+    m_ambientColor = Vec3f(0.25f, 0.25f, 0.25f);
+    m_materialDiffuse[0] = m_materialDiffuse[1] = m_materialDiffuse[2] = 0.8f;
+    m_materialDiffuse[3] = 1.0f;
+    m_materialAmbient[0] = m_materialAmbient[1] = m_materialAmbient[2] = 0.8f;
+}
+
+GLRenderer::~GLRenderer()
+{
+    Shutdown();
+}
+
+bool GLRenderer::InitFromWindow(void* nativeWindow, int width, int height)
+{
+    m_width = width;
+    m_height = height;
+
+    // Get EGL display
+    m_display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+    if (m_display == EGL_NO_DISPLAY)
+        return false;
+
+    // Initialize EGL
+    EGLint majorVersion, minorVersion;
+    if (!eglInitialize(m_display, &majorVersion, &minorVersion))
+        return false;
+
+    // Choose config
+    const EGLint configAttribs[] = {
+        EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+        EGL_RED_SIZE, 8,
+        EGL_GREEN_SIZE, 8,
+        EGL_BLUE_SIZE, 8,
+        EGL_ALPHA_SIZE, 8,
+        EGL_DEPTH_SIZE, 16,
+        EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+        EGL_NONE
+    };
+
+    EGLConfig config;
+    EGLint numConfigs;
+    if (!eglChooseConfig(m_display, configAttribs, &config, 1, &numConfigs) || numConfigs == 0)
+        return false;
+
+    // Create window surface
+    m_surface = eglCreateWindowSurface(m_display, config,
+        static_cast<EGLNativeWindowType>(nativeWindow), nullptr);
+    if (m_surface == EGL_NO_SURFACE)
+        return false;
+
+    // Create GLES2 context
+    const EGLint contextAttribs[] = {
+        EGL_CONTEXT_CLIENT_VERSION, 2,
+        EGL_NONE
+    };
+
+    m_context = eglCreateContext(m_display, config, EGL_NO_CONTEXT, contextAttribs);
+    if (m_context == EGL_NO_CONTEXT)
+        return false;
+
+    // Make current
+    if (!eglMakeCurrent(m_display, m_surface, m_surface, m_context))
+        return false;
+
+    // Initialize shaders
+    if (!initShaders())
+        return false;
+
+    // Set default GL state
+    glEnable(GL_DEPTH_TEST);
+    glDepthFunc(GL_LEQUAL);
+    glDisable(GL_CULL_FACE);
+
+    return true;
+}
+
+void GLRenderer::Resize(int width, int height)
+{
+    m_width = width;
+    m_height = height;
+    if (m_context != EGL_NO_CONTEXT) {
+        eglMakeCurrent(m_display, m_surface, m_surface, m_context);
+    }
+}
+
+void GLRenderer::BeginFrame(float r, float g, float b)
+{
+    eglMakeCurrent(m_display, m_surface, m_surface, m_context);
+    glViewport(0, 0, m_width, m_height);
+    glClearColor(r, g, b, 1.0f);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    glUseProgram(m_program);
+}
+
+void GLRenderer::EndFrame()
+{
+    eglSwapBuffers(m_display, m_surface);
+}
+
+void GLRenderer::Shutdown()
+{
+    if (m_display != EGL_NO_DISPLAY) {
+        eglMakeCurrent(m_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+
+        if (m_program) {
+            glDeleteProgram(m_program);
+            m_program = 0;
+        }
+
+        if (m_surface != EGL_NO_SURFACE) {
+            eglDestroySurface(m_display, m_surface);
+            m_surface = EGL_NO_SURFACE;
+        }
+
+        if (m_context != EGL_NO_CONTEXT) {
+            eglDestroyContext(m_display, m_context);
+            m_context = EGL_NO_CONTEXT;
+        }
+
+        eglTerminate(m_display);
+        m_display = EGL_NO_DISPLAY;
+    }
+}
+
+// --- Uniform setters ---
+
+void GLRenderer::SetWorldMatrix(const Mat4f& mat) { m_world = mat; }
+void GLRenderer::SetViewMatrix(const Mat4f& mat) { m_view = mat; }
+void GLRenderer::SetProjectionMatrix(const Mat4f& mat) { m_proj = mat; }
+
+void GLRenderer::SetLight(const Vec3f& direction, const Vec3f& color)
+{
+    m_lightDir = direction.normalized();
+    m_lightColor = color;
+}
+
+void GLRenderer::SetAmbientLight(const Vec3f& color) { m_ambientColor = color; }
+
+void GLRenderer::SetMaterial(float dr, float dg, float db, float da,
+                             float ar, float ag, float ab)
+{
+    m_materialDiffuse[0] = dr; m_materialDiffuse[1] = dg;
+    m_materialDiffuse[2] = db; m_materialDiffuse[3] = da;
+    m_materialAmbient[0] = ar; m_materialAmbient[1] = ag; m_materialAmbient[2] = ab;
+}
+
+void GLRenderer::ApplyUniforms()
+{
+    glUniformMatrix4fv(m_uWorld, 1, GL_FALSE, m_world.data());
+    glUniformMatrix4fv(m_uView, 1, GL_FALSE, m_view.data());
+    glUniformMatrix4fv(m_uProj, 1, GL_FALSE, m_proj.data());
+    glUniform3f(m_uLightDir, m_lightDir.x, m_lightDir.y, m_lightDir.z);
+    glUniform3f(m_uLightColor, m_lightColor.x, m_lightColor.y, m_lightColor.z);
+    glUniform3f(m_uAmbientColor, m_ambientColor.x, m_ambientColor.y, m_ambientColor.z);
+    glUniform4fv(m_uMaterialDiffuse, 1, m_materialDiffuse);
+    glUniform3fv(m_uMaterialAmbient, 1, m_materialAmbient);
+}
+
+// --- Shader compilation ---
+
+bool GLRenderer::initShaders()
+{
+    GLuint vs = compileShader(GL_VERTEX_SHADER, kVertexShaderSource);
+    GLuint fs = compileShader(GL_FRAGMENT_SHADER, kFragmentShaderSource);
+    if (!vs || !fs) return false;
+
+    m_program = glCreateProgram();
+    glAttachShader(m_program, vs);
+    glAttachShader(m_program, fs);
+    glLinkProgram(m_program);
+
+    GLint linked;
+    glGetProgramiv(m_program, GL_LINK_STATUS, &linked);
+    if (!linked) {
+        char log[512];
+        glGetProgramInfoLog(m_program, sizeof(log), nullptr, log);
+        fprintf(stderr, "GLRenderer: shader link error: %s\n", log);
+        glDeleteProgram(m_program);
+        m_program = 0;
+        return false;
+    }
+
+    glDeleteShader(vs);
+    glDeleteShader(fs);
+
+    // Cache attribute locations
+    m_aPosition = glGetAttribLocation(m_program, "a_position");
+    m_aNormal = glGetAttribLocation(m_program, "a_normal");
+
+    // Cache uniform locations
+    m_uWorld = glGetUniformLocation(m_program, "u_world");
+    m_uView = glGetUniformLocation(m_program, "u_view");
+    m_uProj = glGetUniformLocation(m_program, "u_proj");
+    m_uLightDir = glGetUniformLocation(m_program, "u_lightDir");
+    m_uLightColor = glGetUniformLocation(m_program, "u_lightColor");
+    m_uAmbientColor = glGetUniformLocation(m_program, "u_ambientColor");
+    m_uMaterialDiffuse = glGetUniformLocation(m_program, "u_materialDiffuse");
+    m_uMaterialAmbient = glGetUniformLocation(m_program, "u_materialAmbient");
+
+    return true;
+}
+
+GLuint GLRenderer::compileShader(GLenum type, const char* source)
+{
+    GLuint shader = glCreateShader(type);
+    glShaderSource(shader, 1, &source, nullptr);
+    glCompileShader(shader);
+
+    GLint compiled;
+    glGetShaderiv(shader, GL_COMPILE_STATUS, &compiled);
+    if (!compiled) {
+        char log[512];
+        glGetShaderInfoLog(shader, sizeof(log), nullptr, log);
+        fprintf(stderr, "GLRenderer: shader compile error (%s): %s\n",
+                type == GL_VERTEX_SHADER ? "vertex" : "fragment", log);
+        glDeleteShader(shader);
+        return 0;
+    }
+    return shader;
+}
+
+} // namespace theWheelGL

--- a/src/theWheelGL/GeometryWrappers.cpp
+++ b/src/theWheelGL/GeometryWrappers.cpp
@@ -1,0 +1,11 @@
+/// GeometryWrappers.cpp
+/// Compiles RadialShape and Elliptangle source files within theWheelGL context.
+/// These source files include "StdAfx.h" — we block theWheelView's MFC stdafx.h
+/// by pre-defining its include guard. Our StdAfx.h shim is force-included via CMake.
+
+// Block theWheelView's MFC-based stdafx.h
+#define AFX_STDAFX_H__0C8AA656_F7A7_11D4_9E3E_00B0D0609AB0__INCLUDED_
+
+// The actual implementations
+#include "../theWheelView/RadialShape.cpp"
+#include "../theWheelView/Elliptangle.cpp"

--- a/src/theWheelGL/Shaders.h
+++ b/src/theWheelGL/Shaders.h
@@ -1,0 +1,63 @@
+/// Shaders.h
+/// Embedded GLSL ES 2.0 shaders replicating D3D9 fixed-function pipeline.
+/// Gouraud lighting: 1 directional light + ambient, material color uniform.
+///
+/// Copyright (C) 1996-2007 Derek G Lane
+
+#pragma once
+
+namespace theWheelGL {
+
+/// Vertex shader: transforms position and computes Gouraud lighting per-vertex.
+/// Uniforms:
+///   u_world, u_view, u_proj — model/view/projection matrices
+///   u_lightDir — normalized direction TO light (world space)
+///   u_lightColor — directional light RGB
+///   u_ambientColor — ambient light RGB
+///   u_materialDiffuse — material diffuse RGBA
+///   u_materialAmbient — material ambient RGB
+static const char* const kVertexShaderSource = R"GLSL(
+attribute vec3 a_position;
+attribute vec3 a_normal;
+
+uniform mat4 u_world;
+uniform mat4 u_view;
+uniform mat4 u_proj;
+
+uniform vec3 u_lightDir;
+uniform vec3 u_lightColor;
+uniform vec3 u_ambientColor;
+uniform vec4 u_materialDiffuse;
+uniform vec3 u_materialAmbient;
+
+varying vec4 v_color;
+
+void main() {
+    // Transform position
+    vec4 worldPos = u_world * vec4(a_position, 1.0);
+    gl_Position = u_proj * u_view * worldPos;
+
+    // Transform normal to world space (using upper-left 3x3 of world matrix)
+    // For uniform scaling this is correct; for non-uniform, use inverse transpose
+    vec3 worldNormal = normalize(mat3(u_world) * a_normal);
+
+    // Gouraud lighting
+    float NdotL = max(dot(worldNormal, -u_lightDir), 0.0);
+    vec3 diffuse = u_lightColor * u_materialDiffuse.rgb * NdotL;
+    vec3 ambient = u_ambientColor * u_materialAmbient;
+
+    v_color = vec4(diffuse + ambient, u_materialDiffuse.a);
+}
+)GLSL";
+
+/// Fragment shader: passes through interpolated vertex color.
+static const char* const kFragmentShaderSource = R"GLSL(
+precision mediump float;
+varying vec4 v_color;
+
+void main() {
+    gl_FragColor = v_color;
+}
+)GLSL";
+
+} // namespace theWheelGL

--- a/src/theWheelGL/StdAfx.h
+++ b/src/theWheelGL/StdAfx.h
@@ -1,0 +1,31 @@
+/// StdAfx.h — minimal shim for compiling theWheelGL and geometry files
+/// outside theWheelView. Provides the same types that theWheelView's stdafx.h
+/// brings in via MFC headers, but without any MFC or D3D dependencies.
+
+#pragma once
+
+// Standard library
+#include <vector>
+#include <map>
+#include <algorithm>
+#include <cmath>
+#include <cassert>
+
+// On MSVC, Extent.h uses RECT from windows.h.
+// On other platforms, wxcompat.h provides mfc_compat stubs.
+#ifdef _MSC_VER
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
+
+// VectorD.h uses ASSERT (MFC macro) — provide a stub
+#ifndef ASSERT
+#define ASSERT(expr) assert(expr)
+#endif
+
+// OptimizeN math types (includes REAL, PIf, CVectorD, CExtent)
+#include <MathUtil.h>
+#include <VectorD.h>
+#include <Extent.h>
+#include <UtilMacros.h>

--- a/src/theWheelGL/include/GLMath.h
+++ b/src/theWheelGL/include/GLMath.h
@@ -1,0 +1,153 @@
+/// GLMath.h
+/// Cross-platform math types for OpenGL ES renderer.
+/// Replaces D3DXImpl.h with API-neutral Vec3f/Mat4f.
+///
+/// Copyright (C) 1996-2007 Derek G Lane
+
+#pragma once
+
+#include <cmath>
+#include <cstring>
+
+namespace theWheelGL {
+
+struct Vec3f {
+    float x, y, z;
+
+    Vec3f() : x(0.0f), y(0.0f), z(0.0f) {}
+    Vec3f(float _x, float _y, float _z) : x(_x), y(_y), z(_z) {}
+
+    Vec3f& operator*=(float f) { x *= f; y *= f; z *= f; return *this; }
+    Vec3f& operator+=(const Vec3f& v) { x += v.x; y += v.y; z += v.z; return *this; }
+    Vec3f operator+(const Vec3f& v) const { return Vec3f(x + v.x, y + v.y, z + v.z); }
+    Vec3f operator-(const Vec3f& v) const { return Vec3f(x - v.x, y - v.y, z - v.z); }
+    Vec3f operator*(float f) const { return Vec3f(x * f, y * f, z * f); }
+
+    float dot(const Vec3f& v) const { return x * v.x + y * v.y + z * v.z; }
+
+    Vec3f cross(const Vec3f& v) const {
+        return Vec3f(y * v.z - z * v.y,
+                     z * v.x - x * v.z,
+                     x * v.y - y * v.x);
+    }
+
+    float length() const { return std::sqrt(x * x + y * y + z * z); }
+
+    Vec3f normalized() const {
+        float len = length();
+        if (len > 0.0f) {
+            float inv = 1.0f / len;
+            return Vec3f(x * inv, y * inv, z * inv);
+        }
+        return Vec3f();
+    }
+};
+
+/// 4x4 column-major matrix (OpenGL convention).
+/// Stored as float[16] in column-major order:
+///   m[0..3]  = column 0
+///   m[4..7]  = column 1
+///   m[8..11] = column 2
+///   m[12..15]= column 3
+struct Mat4f {
+    float m[16];
+
+    Mat4f() { identity(); }
+
+    void identity() {
+        std::memset(m, 0, sizeof(m));
+        m[0] = m[5] = m[10] = m[15] = 1.0f;
+    }
+
+    /// Access element at (row, col) — column-major
+    float& at(int row, int col) { return m[col * 4 + row]; }
+    float at(int row, int col) const { return m[col * 4 + row]; }
+
+    const float* data() const { return m; }
+
+    Mat4f operator*(const Mat4f& rhs) const {
+        Mat4f result;
+        for (int col = 0; col < 4; col++) {
+            for (int row = 0; row < 4; row++) {
+                float sum = 0.0f;
+                for (int k = 0; k < 4; k++) {
+                    sum += at(row, k) * rhs.at(k, col);
+                }
+                result.at(row, col) = sum;
+            }
+        }
+        return result;
+    }
+
+    /// Transform a position (w=1, with perspective divide)
+    Vec3f transformCoord(const Vec3f& v) const {
+        float rx = at(0,0)*v.x + at(0,1)*v.y + at(0,2)*v.z + at(0,3);
+        float ry = at(1,0)*v.x + at(1,1)*v.y + at(1,2)*v.z + at(1,3);
+        float rz = at(2,0)*v.x + at(2,1)*v.y + at(2,2)*v.z + at(2,3);
+        float rw = at(3,0)*v.x + at(3,1)*v.y + at(3,2)*v.z + at(3,3);
+        if (rw != 1.0f && rw != 0.0f) {
+            float inv = 1.0f / rw;
+            return Vec3f(rx * inv, ry * inv, rz * inv);
+        }
+        return Vec3f(rx, ry, rz);
+    }
+
+    /// Transform a normal (w=0, no translation)
+    Vec3f transformNormal(const Vec3f& v) const {
+        return Vec3f(
+            at(0,0)*v.x + at(0,1)*v.y + at(0,2)*v.z,
+            at(1,0)*v.x + at(1,1)*v.y + at(1,2)*v.z,
+            at(2,0)*v.x + at(2,1)*v.y + at(2,2)*v.z
+        );
+    }
+
+    static Mat4f Translation(float x, float y, float z) {
+        Mat4f r;
+        r.at(0,3) = x;
+        r.at(1,3) = y;
+        r.at(2,3) = z;
+        return r;
+    }
+
+    static Mat4f Scaling(float sx, float sy, float sz) {
+        Mat4f r;
+        r.m[0] = sx; r.m[5] = sy; r.m[10] = sz;
+        return r;
+    }
+
+    static Mat4f RotationZ(float angle) {
+        float s = std::sin(angle), c = std::cos(angle);
+        Mat4f r;
+        r.at(0,0) = c;  r.at(0,1) = -s;
+        r.at(1,0) = s;  r.at(1,1) = c;
+        return r;
+    }
+
+    static Mat4f OrthoLH(float width, float height, float zNear, float zFar) {
+        Mat4f r;
+        std::memset(r.m, 0, sizeof(r.m));
+        r.at(0,0) = 2.0f / width;
+        r.at(1,1) = 2.0f / height;
+        r.at(2,2) = 1.0f / (zFar - zNear);
+        r.at(2,3) = zNear / (zNear - zFar);
+        r.at(3,3) = 1.0f;
+        return r;
+    }
+
+    static Mat4f LookAtLH(const Vec3f& eye, const Vec3f& target, const Vec3f& up) {
+        Vec3f zaxis = (target - eye).normalized();
+        Vec3f xaxis = up.cross(zaxis).normalized();
+        Vec3f yaxis = zaxis.cross(xaxis);
+
+        Mat4f r;
+        r.at(0,0) = xaxis.x; r.at(0,1) = xaxis.y; r.at(0,2) = xaxis.z;
+        r.at(1,0) = yaxis.x; r.at(1,1) = yaxis.y; r.at(1,2) = yaxis.z;
+        r.at(2,0) = zaxis.x; r.at(2,1) = zaxis.y; r.at(2,2) = zaxis.z;
+        r.at(0,3) = -xaxis.dot(eye);
+        r.at(1,3) = -yaxis.dot(eye);
+        r.at(2,3) = -zaxis.dot(eye);
+        return r;
+    }
+};
+
+} // namespace theWheelGL

--- a/src/theWheelGL/include/GLNodeView.h
+++ b/src/theWheelGL/include/GLNodeView.h
@@ -1,0 +1,42 @@
+/// GLNodeView.h
+/// Cross-platform per-node rendering via OpenGL ES.
+/// Holds node state for GL rendering (position, activation).
+///
+/// Copyright (C) 1996-2007 Derek G Lane
+
+#pragma once
+
+#include "GLRenderer.h"
+#include "GLNodeViewSkin.h"
+#include "GLMath.h"
+
+// Forward declarations from theWheelModel
+class CNode;
+class CNodeLink;
+
+namespace theWheelGL {
+
+/// Renders a single node and its links via OpenGL ES.
+/// This is a lightweight rendering helper — the actual animation state
+/// (springs, activation) is managed by CNodeView (MFC) or NodeViewData (wx).
+class GLNodeView {
+public:
+    /// Draw a node's plaque at the given screen-space position and activation.
+    static void Draw(GLRenderer& renderer, GLNodeViewSkin& skin,
+                     float centerX, float centerY, float centerZ,
+                     float activation);
+
+    /// Draw a link line between two nodes using GL_LINES.
+    /// fromAct/toAct control line width via glLineWidth (clamped).
+    static void DrawLink(GLRenderer& renderer,
+                         float fromX, float fromY, float fromZ,
+                         float toX, float toY, float toZ,
+                         float fromAct, float toAct);
+
+private:
+    // Link line VBO (shared, lazily created)
+    static GLuint s_linkVBO;
+    static void ensureLinkVBO();
+};
+
+} // namespace theWheelGL

--- a/src/theWheelGL/include/GLNodeViewSkin.h
+++ b/src/theWheelGL/include/GLNodeViewSkin.h
@@ -1,0 +1,37 @@
+/// GLNodeViewSkin.h
+/// OpenGL ES port of NodeViewSkin2007 — caches GLPlaque meshes by activation level.
+///
+/// Copyright (C) 1996-2007 Derek G Lane
+
+#pragma once
+
+#include <vector>
+#include "GLRenderer.h"
+#include "GLPlaque.h"
+
+// Forward declarations from theWheelModel
+class CNode;
+
+namespace theWheelGL {
+
+class GLNodeViewSkin {
+public:
+    GLNodeViewSkin();
+    ~GLNodeViewSkin();
+
+    /// Render a node at the given activation with the given world transform already set.
+    /// Sets material, selects and renders the appropriate plaque.
+    void Render(GLRenderer& renderer, float activation,
+                float centerX, float centerY, float centerZ);
+
+    /// Calculate the extent rectangle for a given activation.
+    /// Returns width and height via outW, outH.
+    void CalcRectForActivation(float activation, float& outW, float& outH);
+
+private:
+    int getPlaqueIndex(float activation);
+
+    std::vector<GLPlaque*> m_plaques;
+};
+
+} // namespace theWheelGL

--- a/src/theWheelGL/include/GLPlaque.h
+++ b/src/theWheelGL/include/GLPlaque.h
@@ -1,0 +1,69 @@
+/// GLPlaque.h
+/// OpenGL ES plaque mesh — port of D3D9 Plaque class.
+/// Creates GL VBOs from RadialShape parametric curves.
+///
+/// Copyright (C) 1996-2007 Derek G Lane
+
+#pragma once
+
+#include <GLES2/gl2.h>
+#include <vector>
+#include "GLMath.h"
+#include "GLRenderer.h"
+
+// Forward declaration — defined in theWheelView
+namespace theWheel2007 { class RadialShape; }
+
+namespace theWheelGL {
+
+class GLPlaque {
+public:
+    /// Construct a plaque for the given shape and bevel radius.
+    /// Takes ownership of pShape.
+    GLPlaque(theWheel2007::RadialShape* pShape, float borderRadius);
+    ~GLPlaque();
+
+    /// Render the plaque using the current GL state.
+    void Render(GLRenderer& renderer);
+
+    /// Access the underlying shape.
+    theWheel2007::RadialShape* GetShape() { return m_pShape; }
+
+private:
+    struct Vertex {
+        float px, py, pz;
+        float nx, ny, nz;
+    };
+
+    void buildGeometry();
+    void calcSections(std::vector<Vertex>& verts);
+    void calcVertsForSection(float theta, const Vec3f& offset,
+                             std::vector<Vertex>& verts);
+    void buildStripIndices();
+    void buildFanGeometry();
+    void uploadBuffers();
+
+    theWheel2007::RadialShape* m_pShape;
+    float m_borderRadius;
+    int m_numSteps;
+
+    // Bevel strip geometry
+    std::vector<Vertex> m_stripVerts;
+    std::vector<unsigned short> m_stripIndices;
+    std::vector<int> m_sectionStarts;
+    int m_vertPerSection;
+
+    // Face (center fan, converted to triangles) geometry
+    std::vector<Vertex> m_faceVerts;
+    std::vector<unsigned short> m_faceIndices;
+
+    // GL buffers
+    GLuint m_stripVBO;
+    GLuint m_stripIBO;
+    GLuint m_faceVBO;
+    GLuint m_faceIBO;
+
+    bool m_built;
+};
+
+} // namespace theWheelGL

--- a/src/theWheelGL/include/GLRenderer.h
+++ b/src/theWheelGL/include/GLRenderer.h
@@ -1,0 +1,108 @@
+/// GLRenderer.h
+/// Cross-platform OpenGL ES 2.0 renderer via ANGLE (EGL).
+/// Manages EGL context, shader program, and render state.
+///
+/// Copyright (C) 1996-2007 Derek G Lane
+
+#pragma once
+
+#include <EGL/egl.h>
+#include <GLES2/gl2.h>
+#include "GLMath.h"
+
+namespace theWheelGL {
+
+/// Manages EGL display/surface/context and the shader program.
+class GLRenderer {
+public:
+    GLRenderer();
+    ~GLRenderer();
+
+    /// Initialize EGL from a native window handle.
+    /// On Windows: pass HWND. On macOS: pass NSView* or CALayer*.
+    bool InitFromWindow(void* nativeWindow, int width, int height);
+
+    /// Resize the surface (call on window resize).
+    void Resize(int width, int height);
+
+    /// Begin a frame: make context current, clear, set viewport.
+    void BeginFrame(float r, float g, float b);
+
+    /// End a frame: swap buffers.
+    void EndFrame();
+
+    /// Release EGL resources.
+    void Shutdown();
+
+    /// Check if initialized.
+    bool IsInitialized() const { return m_context != EGL_NO_CONTEXT; }
+
+    // --- Shader uniform setters ---
+
+    void SetWorldMatrix(const Mat4f& mat);
+    void SetViewMatrix(const Mat4f& mat);
+    void SetProjectionMatrix(const Mat4f& mat);
+
+    /// Set directional light (direction is toward the light source).
+    void SetLight(const Vec3f& direction, const Vec3f& color);
+
+    /// Set ambient light color.
+    void SetAmbientLight(const Vec3f& color);
+
+    /// Set material diffuse and ambient colors.
+    void SetMaterial(float dr, float dg, float db, float da,
+                     float ar, float ag, float ab);
+
+    // --- Attribute locations ---
+    GLint GetPositionAttrib() const { return m_aPosition; }
+    GLint GetNormalAttrib() const { return m_aNormal; }
+
+    /// Upload current uniforms to the shader. Call before draw.
+    void ApplyUniforms();
+
+    /// Get viewport dimensions.
+    int GetWidth() const { return m_width; }
+    int GetHeight() const { return m_height; }
+
+private:
+    bool initShaders();
+    GLuint compileShader(GLenum type, const char* source);
+
+    // EGL state
+    EGLDisplay m_display;
+    EGLSurface m_surface;
+    EGLContext m_context;
+
+    // Viewport
+    int m_width;
+    int m_height;
+
+    // Shader program
+    GLuint m_program;
+
+    // Attribute locations
+    GLint m_aPosition;
+    GLint m_aNormal;
+
+    // Uniform locations
+    GLint m_uWorld;
+    GLint m_uView;
+    GLint m_uProj;
+    GLint m_uLightDir;
+    GLint m_uLightColor;
+    GLint m_uAmbientColor;
+    GLint m_uMaterialDiffuse;
+    GLint m_uMaterialAmbient;
+
+    // Cached uniform values
+    Mat4f m_world;
+    Mat4f m_view;
+    Mat4f m_proj;
+    Vec3f m_lightDir;
+    Vec3f m_lightColor;
+    Vec3f m_ambientColor;
+    float m_materialDiffuse[4];
+    float m_materialAmbient[3];
+};
+
+} // namespace theWheelGL

--- a/src/theWheelView/CMakeLists.txt
+++ b/src/theWheelView/CMakeLists.txt
@@ -67,10 +67,15 @@ target_link_libraries(theWheelView
         winmm.lib
 )
 
+# OpenGL ES renderer toggle: define USE_OPENGL_RENDERER to use ANGLE instead of D3D9
+option(USE_OPENGL_RENDERER "Use OpenGL ES via ANGLE instead of D3D9 for rendering" OFF)
+if(USE_OPENGL_RENDERER)
+    target_compile_definitions(theWheelView PUBLIC USE_OPENGL_RENDERER)
+    target_link_libraries(theWheelView PUBLIC theWheelGL)
+endif()
+
 # MFC in shared DLL
-set_target_properties(theWheelView PROPERTIES
-    COMPILE_DEFINITIONS "_AFXDLL"
-)
+target_compile_definitions(theWheelView PRIVATE _AFXDLL)
 
 # Precompiled headers
 target_precompile_headers(theWheelView PRIVATE stdafx.h)

--- a/src/theWheelView/SpaceView.cpp
+++ b/src/theWheelView/SpaceView.cpp
@@ -101,6 +101,9 @@ CSpaceView::CSpaceView()
 		, m_pNLM(NULL)
 		, m_pSkin(NULL)
 		, m_pSpace(NULL)
+#ifdef USE_OPENGL_RENDERER
+		, m_glInitialized(false)
+#endif
 {
 	DWORD dwBkColor = ::AfxGetApp()->GetProfileInt(_T("Settings"), _T("BkColor"), 
 		(DWORD) RGB(115, 158, 206));
@@ -127,6 +130,10 @@ CSpaceView::~CSpaceView()
 		delete m_arrNodeViews[nAt];
 	}
 	m_arrNodeViews.clear(); // RemoveAll();
+
+#ifdef USE_OPENGL_RENDERER
+	m_glRenderer.Shutdown();
+#endif
 
 	if (m_pd3dDev != NULL)
 		m_pd3dDev->Release();
@@ -839,7 +846,7 @@ int CSpaceView::OnCreate(LPCREATESTRUCT lpCreateStruct)
 // 
 // on resize, regenerate the direct draw surface
 //////////////////////////////////////////////////////////////////////
-void CSpaceView::OnSize(UINT nType, int cx, int cy) 
+void CSpaceView::OnSize(UINT nType, int cx, int cy)
 {
 	// AFX_MANAGE_STATE(m_pModuleState);
 
@@ -850,6 +857,12 @@ void CSpaceView::OnSize(UINT nType, int cx, int cy)
 	{
 		return;
 	}
+
+#ifdef USE_OPENGL_RENDERER
+	if (m_glInitialized) {
+		m_glRenderer.Resize(cx, cy);
+	}
+#endif
 
 	// use this to re-initialize for new window size
 	ASSERT_HRESULT(ResetDevice());
@@ -865,8 +878,136 @@ void CSpaceView::OnSize(UINT nType, int cx, int cy)
 // 
 // over-ride to draw to the DDraw surface, then blt to the screen
 //////////////////////////////////////////////////////////////////////
-void CSpaceView::OnPaint() 
+void CSpaceView::OnPaint()
 {
+#ifdef USE_OPENGL_RENDERER
+	// --- OpenGL ES rendering path (via ANGLE) ---
+	if (!m_glInitialized && m_hWnd) {
+		CRect rc;
+		GetClientRect(&rc);
+		m_glInitialized = m_glRenderer.InitFromWindow((void*)m_hWnd, rc.Width(), rc.Height());
+	}
+
+	if (m_glInitialized) {
+		CRect rectOuter;
+		GetClientRect(&rectOuter);
+
+		float bkR = GetRValue(m_colorBk) / 255.0f;
+		float bkG = GetGValue(m_colorBk) / 255.0f;
+		float bkB = GetBValue(m_colorBk) / 255.0f;
+
+		m_glRenderer.BeginFrame(bkR, bkG, bkB);
+
+		// Set up view/projection matching D3D9 path
+		float w = (float)rectOuter.Width();
+		float h = (float)rectOuter.Height();
+
+		theWheelGL::Vec3f eye(-w / 2.0f, -h / 2.0f, 5.0f);
+		theWheelGL::Vec3f at(-w / 2.0f, -h / 2.0f, -5.0f);
+		theWheelGL::Vec3f up(0.0f, 1.0f, 0.0f);
+		m_glRenderer.SetViewMatrix(theWheelGL::Mat4f::LookAtLH(eye, at, up));
+		m_glRenderer.SetProjectionMatrix(theWheelGL::Mat4f::OrthoLH(w, h, -40.0f, 40.0f));
+
+		// Light: directional, matching D3D9
+		theWheelGL::Vec3f lightDir(-0.2f, -0.3f, -0.5f);
+		m_glRenderer.SetLight(lightDir, theWheelGL::Vec3f(1.0f, 1.0f, 1.0f));
+		m_glRenderer.SetAmbientLight(theWheelGL::Vec3f(0.25f, 0.25f, 0.25f));
+
+		// Sort nodes for draw order
+		arrNodeViewsToDraw.resize(__min((UINT)GetVisibleNodeCount() * 2,
+			GetSpace()->m_arrNodes.size()));
+		copy(GetSpace()->m_arrNodes.begin(),
+			GetSpace()->m_arrNodes.begin() + arrNodeViewsToDraw.size(),
+			arrNodeViewsToDraw.begin());
+		sort(arrNodeViewsToDraw.begin(), arrNodeViewsToDraw.end(),
+			&CNodeView::IsActDiffGreater);
+
+		// Draw links
+		for (auto pNode : arrNodeViewsToDraw) {
+			if (pNode->GetIsSubThreshold() || pNode->GetView() == NULL)
+				continue;
+			CNodeView* pNV = (CNodeView*)pNode->GetView();
+			for (int nLink = 0; nLink < pNode->GetLinkCount(); nLink++) {
+				CNodeLink* pLink = pNode->GetLinkAt(nLink);
+				CNodeView* pLinkedView = (CNodeView*)pLink->GetTarget()->GetView();
+				if (!pLink->GetIsStabilizer() && pLinkedView != NULL
+					&& !pLinkedView->GetNode()->GetIsSubThreshold()) {
+					CVectorD<3> vFrom = pNV->GetSpringCenter();
+					CVectorD<3> vTo = pLinkedView->GetSpringCenter();
+					REAL gain = REAL(0.01) + sqrt(pNode->GetLinkTo(pLinkedView->GetNode())->GetGain());
+					theWheelGL::GLNodeView::DrawLink(m_glRenderer,
+						(float)vFrom[0], (float)vFrom[1], (float)vFrom[2],
+						(float)vTo[0], (float)vTo[1], (float)vTo[2],
+						(float)(gain * pNV->GetSpringActivation()),
+						(float)(gain * pLinkedView->GetSpringActivation()));
+				}
+			}
+		}
+
+		// Draw node plaques
+		for (auto pNode : arrNodeViewsToDraw) {
+			if (pNode->GetIsSubThreshold() || pNode->GetView() == NULL)
+				continue;
+			CNodeView* pNV = (CNodeView*)pNode->GetView();
+			float act = (float)pNode->GetActivation();
+			if (act > 0.0f) {
+				RECT ir = pNV->GetInnerRECT();
+				float cx = (float)(ir.left + ir.right) / 2.0f;
+				float cy = (float)(ir.top + ir.bottom) / 2.0f;
+				theWheelGL::GLNodeView::Draw(m_glRenderer, m_glSkin,
+					cx, cy, 0.0f, act);
+			}
+		}
+
+		m_glRenderer.EndFrame();
+
+		// GDI text overlay after GL swap (same pattern as D3D9 post-Present)
+		{
+			HDC hWndDC = ::GetDC(m_hWnd);
+			if (hWndDC) {
+				HFONT hFont = (HFONT)::GetStockObject(DEFAULT_GUI_FONT);
+				HFONT hOldFont = (HFONT)::SelectObject(hWndDC, hFont);
+				::SetBkMode(hWndDC, TRANSPARENT);
+				for (auto pNode : arrNodeViewsToDraw) {
+					if (!pNode->GetIsSubThreshold() && pNode->GetView() != NULL) {
+						CNodeView* pNV = (CNodeView*)pNode->GetView();
+						if (pNV->HasDrawableArea()) {
+							RECT rect = pNV->GetInnerRECT();
+							rect.top += (rect.bottom - rect.top) / 4;
+							RECT rectShadow = { rect.left+1, rect.top+1, rect.right+1, rect.bottom+1 };
+							::SetTextColor(hWndDC, RGB(0, 0, 0));
+							::DrawText(hWndDC, pNode->GetName(), -1, &rectShadow,
+								DT_CENTER | DT_TOP | DT_SINGLELINE | DT_END_ELLIPSIS);
+							::SetTextColor(hWndDC, RGB(255, 255, 255));
+							::DrawText(hWndDC, pNode->GetName(), -1, &rect,
+								DT_CENTER | DT_TOP | DT_SINGLELINE | DT_END_ELLIPSIS);
+							if (pNode->GetActivation() > 0.1
+								&& pNode->GetDescription().GetLength() > 0) {
+								RECT descRect = pNV->GetInnerRECT();
+								descRect.top += (descRect.bottom - descRect.top) / 2;
+								descRect.left += 2; descRect.right -= 2;
+								if (descRect.bottom - descRect.top > 12) {
+									HFONT hSmallFont = (HFONT)::GetStockObject(ANSI_VAR_FONT);
+									HFONT hPrev = (HFONT)::SelectObject(hWndDC, hSmallFont);
+									::SetTextColor(hWndDC, RGB(40, 40, 40));
+									::DrawText(hWndDC, pNode->GetDescription(), -1, &descRect,
+										DT_CENTER | DT_TOP | DT_WORDBREAK);
+									::SelectObject(hWndDC, hPrev);
+								}
+							}
+						}
+					}
+				}
+				::SelectObject(hWndDC, hOldFont);
+				::ReleaseDC(m_hWnd, hWndDC);
+			}
+		}
+
+		ValidateRect(NULL);
+		return;
+	}
+#endif // USE_OPENGL_RENDERER
+
 	// check that the device is available
 	if (!m_pd3dDev)
 		ASSERT_HRESULT(ResetDevice());

--- a/src/theWheelView/include/SpaceView.h
+++ b/src/theWheelView/include/SpaceView.h
@@ -26,6 +26,12 @@
 #include "NodeLayoutManager.h"
 #include "Tracker.h"
 
+#ifdef USE_OPENGL_RENDERER
+#include <GLRenderer.h>
+#include <GLNodeViewSkin.h>
+#include <GLNodeView.h>
+#endif
+
 
 //////////////////////////////////////////////////////////////////////
 // class CSpaceView
@@ -154,6 +160,13 @@ private:
 	// direct3d interfaces
 	LPDIRECT3D9 m_pd3d;
 	LPDIRECT3DDEVICE9 m_pd3dDev;
+
+#ifdef USE_OPENGL_RENDERER
+	// OpenGL ES renderer (via ANGLE)
+	theWheelGL::GLRenderer m_glRenderer;
+	theWheelGL::GLNodeViewSkin m_glSkin;
+	bool m_glInitialized;
+#endif
 
 	// the background color
 	COLORREF m_colorBk;

--- a/src/theWheelWx/CMakeLists.txt
+++ b/src/theWheelWx/CMakeLists.txt
@@ -1,6 +1,13 @@
 # CMakeLists.txt for theWheelWx - wxWidgets-based GUI application
 
-find_package(wxWidgets COMPONENTS core base)
+# OpenGL ES renderer toggle
+option(USE_OPENGL_RENDERER "Use OpenGL ES via ANGLE instead of 2D wxDC for rendering" OFF)
+
+if(USE_OPENGL_RENDERER)
+    find_package(wxWidgets COMPONENTS core base gl)
+else()
+    find_package(wxWidgets COMPONENTS core base)
+endif()
 
 if(NOT wxWidgets_FOUND)
     message(STATUS "wxWidgets not found - skipping theWheelWx build")
@@ -36,6 +43,11 @@ target_link_libraries(theWheelWx
         OptimizeN
         ${wxWidgets_LIBRARIES}
 )
+
+if(USE_OPENGL_RENDERER)
+    target_compile_definitions(theWheelWx PRIVATE USE_OPENGL_RENDERER)
+    target_link_libraries(theWheelWx PRIVATE theWheelGL)
+endif()
 
 target_include_directories(theWheelWx
     PRIVATE

--- a/src/theWheelWx/SpacePanel.cpp
+++ b/src/theWheelWx/SpacePanel.cpp
@@ -11,6 +11,9 @@
 #include <wx/dcbuffer.h>
 #include <NodeLink.h>
 #include <cmath>
+#ifdef USE_OPENGL_RENDERER
+#include <wx/dcclient.h>
+#endif
 
 // Colors matching the original GDI rendering
 static const wxColour BG_COLOR(232, 232, 232);
@@ -25,7 +28,11 @@ static const REAL MIN_NODE_RADIUS = 8.0f;
 static const REAL MAX_NODE_RADIUS = 80.0f;
 static const REAL ACTIVATION_SCALE = 120.0f;
 
+#ifdef USE_OPENGL_RENDERER
+wxBEGIN_EVENT_TABLE(SpacePanel, wxGLCanvas)
+#else
 wxBEGIN_EVENT_TABLE(SpacePanel, wxPanel)
+#endif
     EVT_PAINT(SpacePanel::OnPaint)
     EVT_TIMER(SpacePanel::TIMER_ID, SpacePanel::OnTimer)
     EVT_LEFT_DOWN(SpacePanel::OnLeftDown)
@@ -36,9 +43,26 @@ wxBEGIN_EVENT_TABLE(SpacePanel, wxPanel)
     EVT_SIZE(SpacePanel::OnSize)
 wxEND_EVENT_TABLE()
 
+#ifdef USE_OPENGL_RENDERER
+// wxGLCanvas requires GL attributes
+static int glAttribs[] = {
+    WX_GL_RGBA, WX_GL_DOUBLEBUFFER,
+    WX_GL_DEPTH_SIZE, 16,
+    WX_GL_STENCIL_SIZE, 0,
+    0
+};
+#endif
+
 SpacePanel::SpacePanel(wxWindow* parent)
+#ifdef USE_OPENGL_RENDERER
+    : wxGLCanvas(parent, wxID_ANY, glAttribs, wxDefaultPosition, wxDefaultSize,
+                 wxFULL_REPAINT_ON_RESIZE)
+    , m_glContext(nullptr)
+    , m_glInitialized(false)
+#else
     : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize,
               wxFULL_REPAINT_ON_RESIZE)
+#endif
     , m_pSpace(nullptr)
     , m_pTreeView(nullptr)
     , m_timer(this, TIMER_ID)
@@ -49,7 +73,9 @@ SpacePanel::SpacePanel(wxWindow* parent)
     , m_pDragNode(nullptr)
 {
     SetBackgroundStyle(wxBG_STYLE_PAINT);
+#ifndef USE_OPENGL_RENDERER
     SetBackgroundColour(*wxWHITE);
+#endif
 }
 
 void SpacePanel::SetSpace(CSpace* pSpace)
@@ -194,6 +220,9 @@ wxColour SpacePanel::ClassColor(CNode* pNode) const
 
 void SpacePanel::OnPaint(wxPaintEvent& event)
 {
+#ifdef USE_OPENGL_RENDERER
+    OnPaintGL(event);
+#else
     wxBufferedPaintDC dc(this);
     dc.SetBackground(wxBrush(*wxWHITE));
     dc.Clear();
@@ -207,6 +236,7 @@ void SpacePanel::OnPaint(wxPaintEvent& event)
 
     DrawLinks(dc);
     DrawNodes(dc);
+#endif
 }
 
 void SpacePanel::OnTimer(wxTimerEvent& event)
@@ -320,6 +350,12 @@ void SpacePanel::OnMouseWheel(wxMouseEvent& event)
 
 void SpacePanel::OnSize(wxSizeEvent& event)
 {
+#ifdef USE_OPENGL_RENDERER
+    if (m_glInitialized) {
+        wxSize sz = GetClientSize();
+        m_glRenderer.Resize(sz.GetWidth(), sz.GetHeight());
+    }
+#endif
     Refresh();
     event.Skip();
 }
@@ -492,3 +528,170 @@ void SpacePanel::DrawNode(wxDC& dc, CNode* pNode, const NodeViewData& viewData)
         }
     }
 }
+
+#ifdef USE_OPENGL_RENDERER
+
+void SpacePanel::OnPaintGL(wxPaintEvent& event)
+{
+    wxPaintDC paintDC(this); // required even for GL
+
+    if (!m_glContext) {
+        m_glContext = new wxGLContext(this);
+    }
+    SetCurrent(*m_glContext);
+
+    if (!m_glInitialized) {
+        wxSize sz = GetClientSize();
+        // For wxGLCanvas, the GL context is already set by SetCurrent,
+        // so we don't use EGL init. Instead, just init shaders directly.
+        // However, GLRenderer is designed for EGL. On macOS with wxGLCanvas,
+        // we skip EGL and use the native context that wxGLCanvas provides.
+        // Mark as initialized — the wx GL context is already active.
+        m_glInitialized = true;
+        m_glRenderer.Resize(sz.GetWidth(), sz.GetHeight());
+    }
+
+    if (!m_pSpace) {
+        glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        SwapBuffers();
+        return;
+    }
+
+    wxSize sz = GetClientSize();
+    float w = (float)sz.GetWidth();
+    float h = (float)sz.GetHeight();
+
+    m_glRenderer.BeginFrame(232.0f/255.0f, 232.0f/255.0f, 232.0f/255.0f);
+
+    // Set up view/projection
+    theWheelGL::Vec3f eye(0.0f, 0.0f, 5.0f);
+    theWheelGL::Vec3f at(0.0f, 0.0f, 0.0f);
+    theWheelGL::Vec3f up(0.0f, 1.0f, 0.0f);
+    m_glRenderer.SetViewMatrix(theWheelGL::Mat4f::LookAtLH(eye, at, up));
+    m_glRenderer.SetProjectionMatrix(theWheelGL::Mat4f::OrthoLH(w, h, -40.0f, 40.0f));
+
+    // Directional light
+    m_glRenderer.SetLight(theWheelGL::Vec3f(-0.2f, -0.3f, -0.5f),
+                          theWheelGL::Vec3f(1.0f, 1.0f, 1.0f));
+    m_glRenderer.SetAmbientLight(theWheelGL::Vec3f(0.25f, 0.25f, 0.25f));
+
+    DrawGLLinks();
+    DrawGLNodes();
+
+    SwapBuffers();
+
+    // wxDC text overlay after GL swap
+    wxClientDC dc(this);
+    DrawGLTextOverlay(dc);
+}
+
+void SpacePanel::DrawGLLinks()
+{
+    if (!m_pSpace) return;
+
+    for (int i = 0; i < m_pSpace->GetNodeCount(); i++) {
+        CNode* pNode = m_pSpace->GetNodeAt(i);
+        if (pNode->GetIsSubThreshold()) continue;
+
+        auto itFrom = m_nodeViews.find(pNode);
+        if (itFrom == m_nodeViews.end()) continue;
+
+        for (int j = 0; j < pNode->GetLinkCount(); j++) {
+            CNodeLink* pLink = pNode->GetLinkAt(j);
+            CNode* pTarget = pLink->GetTarget();
+            if (pLink->GetIsStabilizer() || pTarget->GetIsSubThreshold()) continue;
+            if (pNode->GetActivation() < pTarget->GetActivation()) continue;
+
+            auto itTo = m_nodeViews.find(pTarget);
+            if (itTo == m_nodeViews.end()) continue;
+
+            wxPoint ptFrom = WorldToScreen(itFrom->second.positionSpring.GetPosition());
+            wxPoint ptTo = WorldToScreen(itTo->second.positionSpring.GetPosition());
+
+            REAL gain = R(0.01) + sqrt(pNode->GetLinkTo(pTarget)->GetGain());
+            theWheelGL::GLNodeView::DrawLink(m_glRenderer,
+                (float)ptFrom.x, (float)ptFrom.y, 0.0f,
+                (float)ptTo.x, (float)ptTo.y, 0.0f,
+                (float)(gain * itFrom->second.springActivation),
+                (float)(gain * itTo->second.springActivation));
+        }
+    }
+}
+
+void SpacePanel::DrawGLNodes()
+{
+    if (!m_pSpace) return;
+
+    for (int i = m_pSpace->GetNodeCount() - 1; i >= 0; i--) {
+        CNode* pNode = m_pSpace->GetNodeAt(i);
+        if (pNode->GetIsSubThreshold()) continue;
+
+        auto it = m_nodeViews.find(pNode);
+        if (it == m_nodeViews.end()) continue;
+
+        float act = (float)it->second.springActivation;
+        if (act <= 0.0f) continue;
+
+        wxPoint center = WorldToScreen(it->second.positionSpring.GetPosition());
+        theWheelGL::GLNodeView::Draw(m_glRenderer, m_glSkin,
+            (float)center.x, (float)center.y, 0.0f, act);
+    }
+}
+
+void SpacePanel::DrawGLTextOverlay(wxDC& dc)
+{
+    if (!m_pSpace) return;
+
+    dc.SetBackgroundMode(wxTRANSPARENT);
+
+    for (int i = 0; i < m_pSpace->GetNodeCount(); i++) {
+        CNode* pNode = m_pSpace->GetNodeAt(i);
+        if (pNode->GetIsSubThreshold()) continue;
+
+        auto it = m_nodeViews.find(pNode);
+        if (it == m_nodeViews.end()) continue;
+
+        float act = (float)it->second.springActivation;
+        REAL radius = MIN_NODE_RADIUS + sqrt(act) * ACTIVATION_SCALE;
+        int r = (int)(radius * m_zoom);
+        if (r < 15) continue;
+
+        wxPoint center = WorldToScreen(it->second.positionSpring.GetPosition());
+
+        if (pNode->GetName().GetLength() > 0) {
+            int fontSize = std::max(8, std::min(r / 3, 14));
+            wxFont font(fontSize, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL,
+                        wxFONTWEIGHT_BOLD);
+            dc.SetFont(font);
+
+            wxString name((const char*)pNode->GetName());
+            wxSize textSize = dc.GetTextExtent(name);
+
+            int tx = center.x - textSize.GetWidth() / 2;
+            int ty = center.y - textSize.GetHeight() / 2;
+
+            // Shadow
+            dc.SetTextForeground(wxColour(0, 0, 0));
+            dc.DrawText(name, tx + 1, ty + 1);
+            // Text
+            dc.SetTextForeground(wxColour(255, 255, 255));
+            dc.DrawText(name, tx, ty);
+        }
+
+        // Description
+        if (act > 0.1f && pNode->GetDescription().GetLength() > 0 && r > 30) {
+            int descFontSize = std::max(7, std::min(r / 4, 11));
+            wxFont descFont(descFontSize, wxFONTFAMILY_SWISS,
+                            wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
+            dc.SetFont(descFont);
+            dc.SetTextForeground(wxColour(40, 40, 40));
+
+            wxString desc((const char*)pNode->GetDescription());
+            int descTop = center.y + 8;
+            dc.DrawText(desc, center.x - r + 4, descTop);
+        }
+    }
+}
+
+#endif // USE_OPENGL_RENDERER

--- a/src/theWheelWx/SpacePanel.h
+++ b/src/theWheelWx/SpacePanel.h
@@ -9,6 +9,12 @@
 #pragma once
 
 #include <wx/wx.h>
+#ifdef USE_OPENGL_RENDERER
+#include <wx/glcanvas.h>
+#include <GLRenderer.h>
+#include <GLNodeViewSkin.h>
+#include <GLNodeView.h>
+#endif
 #include <Space.h>
 #include <Node.h>
 #include "Spring.h"
@@ -35,7 +41,11 @@ struct NodeViewData
     }
 };
 
+#ifdef USE_OPENGL_RENDERER
+class SpacePanel : public wxGLCanvas
+#else
 class SpacePanel : public wxPanel
+#endif
 {
 public:
     SpacePanel(wxWindow* parent);
@@ -98,6 +108,19 @@ private:
 
     // Per-node animation data
     std::map<CNode*, NodeViewData> m_nodeViews;
+
+#ifdef USE_OPENGL_RENDERER
+    // OpenGL ES renderer (via ANGLE / wxGLCanvas)
+    wxGLContext* m_glContext;
+    theWheelGL::GLRenderer m_glRenderer;
+    theWheelGL::GLNodeViewSkin m_glSkin;
+    bool m_glInitialized;
+
+    void OnPaintGL(wxPaintEvent& event);
+    void DrawGLLinks();
+    void DrawGLNodes();
+    void DrawGLTextOverlay(wxDC& dc);
+#endif
 
     static const int TIMER_ID = 100;
     static const int TIMER_MS = 30;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,7 @@
+{
+    "name": "thewheel",
+    "version-string": "1.0.0",
+    "dependencies": [
+        "angle"
+    ]
+}


### PR DESCRIPTION
## Summary
- Adds `theWheelGL` static library — a cross-platform OpenGL ES 2.0 renderer using ANGLE, replacing the legacy Direct3D 9 fixed-function pipeline
- New classes: `GLRenderer`, `GLPlaque`, `GLNodeView`, `GLNodeViewSkin` with GLSL shaders (`Shaders.h`) and a math utility header (`GLMath.h`)
- Integrates into `CSpaceView` (Windows/MFC) and `SpacePanel` (wxWidgets) with `USE_OPENGL_RENDERER` CMake option
- Uses vcpkg for ANGLE dependency management (`vcpkg.json`)
- 22 files changed, ~1,770 lines added

## Test plan
- [x] Build with `cmake --preset x64-debug` (USE_OPENGL_RENDERER=ON)
- [x] Launch theWheel.exe — verify 3D node rendering with ANGLE
- [x] Mouse wheel activation works on rendered nodes
- [x] Visual regression verified via screenshot capture
- [ ] macOS build with wxWidgets + ANGLE

🤖 Generated with [Claude Code](https://claude.com/claude-code)