### PR TITLE
Remove MFC dependencies from OptimizeN, rename classes

### DIFF
--- a/src/OptimizeN/BrentOptimizer.cpp
+++ b/src/OptimizeN/BrentOptimizer.cpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////
-// BrentOptimizer.cpp: implementation of the CBrentOptimizer
+// BrentOptimizer.cpp: implementation of the BrentOptimizer
 //
 // Copyright (C) 1996-2001
 // $Id: BrentOptimizer.cpp,v 1.13 2007/05/09 01:53:42 Derek Lane Exp $
@@ -52,16 +52,16 @@ const int ITER_MAX = 1000;		// maximum iteration
 
 
 // holds the initial value for the brent optimization
-CVectorN<> CBrentOptimizer::m_vBrentInit(1);
+VectorN<> BrentOptimizer::m_vBrentInit(1);
 
 
 //////////////////////////////////////////////////////////////////////
-// CBrentOptimizer::CBrentOptimizer
+// BrentOptimizer::BrentOptimizer
 // 
 // constructs a new Brent optimizer
 //////////////////////////////////////////////////////////////////////
-CBrentOptimizer::CBrentOptimizer(CObjectiveFunction *pFunc)
-	: COptimizer(pFunc),
+BrentOptimizer::BrentOptimizer(ObjectiveFunction *pFunc)
+	: Optimizer(pFunc),
 		m_vAx(1), 
 		m_vBx(1), 
 		m_vCx(1),
@@ -79,13 +79,13 @@ CBrentOptimizer::CBrentOptimizer(CObjectiveFunction *pFunc)
 }
 
 //////////////////////////////////////////////////////////////////////
-// CBrentOptimizer::Optimize
+// BrentOptimizer::Optimize
 // 
 // performs the optimization given the initial value vector
 //////////////////////////////////////////////////////////////////////
-const CVectorN<>& CBrentOptimizer::Optimize(const CVectorN<>& vInit)
+const VectorN<>& BrentOptimizer::Optimize(const VectorN<>& vInit)
 {
-	BEGIN_LOG_SECTION(CBrentOptimizer::Optimize);
+	BEGIN_LOG_SECTION(BrentOptimizer::Optimize);
 
 	// find three values the bracket a minimum
 	REAL ax = vInit[0];
@@ -113,14 +113,14 @@ const CVectorN<>& CBrentOptimizer::Optimize(const CVectorN<>& vInit)
 	m_vFinalParam.SetDim(1);	// 1-d for a brent optimizer
 	m_vFinalParam[0] = finalx;
 
-	END_LOG_SECTION();	// CBrentOptimizer::Optimize
+	END_LOG_SECTION();	// BrentOptimizer::Optimize
 
 	// and return it
 	return m_vFinalParam;
 }
 
 //////////////////////////////////////////////////////////////////////
-// CBrentOptimizer<REAL>::BracketMinimum
+// BrentOptimizer<REAL>::BracketMinimum
 // 
 // Given two distinct initial points ax and bx, this routine searches downhill 
 // (defined by the function as evaluated at the initial points) and returns new 
@@ -134,11 +134,11 @@ const CVectorN<>& CBrentOptimizer::Optimize(const CVectorN<>& vInit)
 // Recipes in C, 2nd Ed. 1992.
 //
 //////////////////////////////////////////////////////////////////////
-void CBrentOptimizer::BracketMinimum(REAL& ax, REAL& bx, REAL& cx)
+void BrentOptimizer::BracketMinimum(REAL& ax, REAL& bx, REAL& cx)
 {
 	USES_CONVERSION;
 
-	BEGIN_LOG_SECTION(CBrentOptimizer::BracketMinimum);
+	BEGIN_LOG_SECTION(BrentOptimizer::BracketMinimum);
 
 	REAL fa, fb, fc;
 
@@ -171,7 +171,7 @@ void CBrentOptimizer::BracketMinimum(REAL& ax, REAL& bx, REAL& cx)
 	m_nIteration = 0;
 	while (fb > fc)
 	{
-		BEGIN_LOG_SECTION("CBrentOptimizer::BracketMinimum!Iteration");
+		BEGIN_LOG_SECTION("BrentOptimizer::BracketMinimum!Iteration");
 		LOG(_T("Iteration %i"), m_nIteration);
 
 		// Compute u by parabolic extrapolation from a,b,c.  TINY is used to 
@@ -257,12 +257,12 @@ void CBrentOptimizer::BracketMinimum(REAL& ax, REAL& bx, REAL& cx)
 	}
 
 cleanup:
-	END_LOG_SECTION();		// CBrentOptimizer::BracketMinimum
+	END_LOG_SECTION();		// BrentOptimizer::BracketMinimum
 }
 
 
 //////////////////////////////////////////////////////////////////////
-// CBrentOptimizer<REAL>::FindMinimum
+// BrentOptimizer<REAL>::FindMinimum
 // 
 // Given a function f, and given a bracketing triplet of abscissas
 // ax, bx, cx, (such that bx is between ax and cx, and f(bx) < f(ax)
@@ -279,13 +279,13 @@ cleanup:
 // intertions before stopping 
 //////////////////////////////////////////////////////////////////////
 // template<class REAL>
-REAL CBrentOptimizer::FindMinimum (REAL ax, REAL bx, REAL cx)
+REAL BrentOptimizer::FindMinimum (REAL ax, REAL bx, REAL cx)
 {
 	USES_CONVERSION;
 
 	REAL fx, x;
 
-	BEGIN_LOG_SECTION(CBrentOptimizer::FindMinimum);
+	BEGIN_LOG_SECTION(BrentOptimizer::FindMinimum);
 
 	// The following are intermediate computed values. 
 	REAL a,b,d,etemp,fu,fv,fw,p,q,r,tol1,tol2,u,v,w,xm;
@@ -302,7 +302,7 @@ REAL CBrentOptimizer::FindMinimum (REAL ax, REAL bx, REAL cx)
 	// Main function loop. 
 	for (m_nIteration = 0; m_nIteration < ITER_MAX; m_nIteration++)
 	{
-		BEGIN_LOG_SECTION(CBrentOptimizer::FindMinimum!Iteration);
+		BEGIN_LOG_SECTION(BrentOptimizer::FindMinimum!Iteration);
 		LOG(_T("Iteration %i"), m_nIteration);
 
 		xm = (REAL) 0.5*(a+b);
@@ -387,14 +387,14 @@ REAL CBrentOptimizer::FindMinimum (REAL ax, REAL bx, REAL cx)
 	LOG(_T("Too many iterations = %i"), m_nIteration);
 
 cleanup:
-	END_LOG_SECTION();	// CBrentOptimizer::BracketMinimum
+	END_LOG_SECTION();	// BrentOptimizer::BracketMinimum
 
 	m_finalValue = fx;
 	return x;
 }
 
 //////////////////////////////////////////////////////////////////////
-// CBrentOptimizer<REAL>::FindMinimumGrad
+// BrentOptimizer<REAL>::FindMinimumGrad
 // 
 // Given a function f, and given a bracketing triplet of abscissas
 // ax, bx, cx, (such that bx is between ax and cx, and f(bx) < f(ax)
@@ -410,7 +410,7 @@ cleanup:
 // tol is variable specifing the minimum agreement needed between successive 
 // intertions before stopping 
 ///////////////////////////////////////////////////////////////////////
-REAL CBrentOptimizer::FindMinimumGrad(REAL ax, REAL bx, REAL cx)
+REAL BrentOptimizer::FindMinimumGrad(REAL ax, REAL bx, REAL cx)
 {
 	// a and b must be in ascending order, but input abscissas need not be.
 	REAL a=(ax < cx ? ax : cx);
@@ -580,12 +580,12 @@ REAL CBrentOptimizer::FindMinimumGrad(REAL ax, REAL bx, REAL cx)
 	return 0.0;
 }
 
-const CVectorN<>& CBrentOptimizer::GetInitZero()
+const VectorN<>& BrentOptimizer::GetInitZero()
 {
 	return m_vBrentInit;
 }
 
-void CBrentOptimizer::SetParams(REAL Bracket, REAL GLimit)
+void BrentOptimizer::SetParams(REAL Bracket, REAL GLimit)
 {
 	m_Bracket = Bracket;
 	m_GLimit = GLimit;

--- a/src/OptimizeN/CMakeLists.txt
+++ b/src/OptimizeN/CMakeLists.txt
@@ -32,7 +32,7 @@ set(OPTIMIZEN_HEADERS
     include/UtilMacros.h
     include/VectorN.h
     include/VectorOps.h
-    include/mfc_compat.h
+    include/optimize_types.h
     stdafx.h
 )
 

--- a/src/OptimizeN/ConjGradOptimizer.cpp
+++ b/src/OptimizeN/ConjGradOptimizer.cpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////
-// ConjGradOptimizer.cpp: implementation of the CBrentOptimizer
+// ConjGradOptimizer.cpp: implementation of the BrentOptimizer
 //
 // Copyright (C) 1996-2001
 // $Id: ConjGradOptimizer.cpp,v 1.19 2007/05/28 18:28:30 Derek Lane Exp $
@@ -24,12 +24,12 @@ const int ITER_MAX = 500;
 const REAL ZEPS = (REAL) 1.0e-10;	
 
 ///////////////////////////////////////////////////////////////////////////////
-// CConjGradOptimizer::CConjGradOptimizer
+// ConjGradOptimizer::ConjGradOptimizer
 // 
 // construct a gradient optimizer for an objective function
 ///////////////////////////////////////////////////////////////////////////////
-CConjGradOptimizer::CConjGradOptimizer(CObjectiveFunction *pFunc)
-	: COptimizer(pFunc),
+ConjGradOptimizer::ConjGradOptimizer(ObjectiveFunction *pFunc)
+	: Optimizer(pFunc),
 		m_lineFunction(pFunc),
 		m_pLineOptimizer(&m_optimizeBrent),
 		m_optimizeBrent(&m_lineFunction),
@@ -39,31 +39,31 @@ CConjGradOptimizer::CConjGradOptimizer(CObjectiveFunction *pFunc)
 	// set the Brent optimizer to use the gradient information
 	m_optimizeBrent.SetUseGradientInfo(FALSE);
 
-}	// CConjGradOptimizer::CConjGradOptimizer
+}	// ConjGradOptimizer::ConjGradOptimizer
 
 
 ///////////////////////////////////////////////////////////////////////////////
-// CConjGradOptimizer::GetBrentOptimizer
+// ConjGradOptimizer::GetBrentOptimizer
 // 
 // returns the embedded line optimizer
 ///////////////////////////////////////////////////////////////////////////////
-CBrentOptimizer& CConjGradOptimizer::GetBrentOptimizer()
+BrentOptimizer& ConjGradOptimizer::GetBrentOptimizer()
 {
 	return m_optimizeBrent;
 
-}	// CConjGradOptimizer::GetBrentOptimizer
+}	// ConjGradOptimizer::GetBrentOptimizer
 
 
 ///////////////////////////////////////////////////////////////////////////////
-// CConjGradOptimizer::Optimize
+// ConjGradOptimizer::Optimize
 // 
 // performs the optimization given the initial value vector
 ///////////////////////////////////////////////////////////////////////////////
-const CVectorN<>& CConjGradOptimizer::Optimize(const CVectorN<>& vInit)
+const VectorN<>& ConjGradOptimizer::Optimize(const VectorN<>& vInit)
 {
 	USES_CONVERSION;
 
-	BEGIN_LOG_SECTION(CConjGradOptimizer::Optimize);
+	BEGIN_LOG_SECTION(ConjGradOptimizer::Optimize);
 	LOG_EXPR_EXT(vInit);
 
 	// set the tolerance for the line optimizer
@@ -122,13 +122,13 @@ const CVectorN<>& CConjGradOptimizer::Optimize(const CVectorN<>& vInit)
 		///////////////////////////////////////////////////////////////////////////////
 		// line minimization
 
-		BEGIN_LOG_SECTION(CConjGradOptimizer::Optimize!Line_Minimization);
+		BEGIN_LOG_SECTION(ConjGradOptimizer::Optimize!Line_Minimization);
 
 		// set up the direction for the line minimization
 		m_lineFunction.SetLine(m_vFinalParam, m_vDir); // m_vGrad);
 
 		// now launch a line optimization
-		REAL lambda = m_pLineOptimizer->Optimize(CBrentOptimizer::GetInitZero())[0];
+		REAL lambda = m_pLineOptimizer->Optimize(BrentOptimizer::GetInitZero())[0];
 		LOG_EXPR(lambda);
 
 		// update the final parameter value
@@ -172,7 +172,7 @@ const CVectorN<>& CConjGradOptimizer::Optimize(const CVectorN<>& vInit)
 			m_mOrthoBasis[m_nIteration].Normalize();
 
 			// stores the projection vector
-			static CVectorN<> vProj;
+			static VectorN<> vProj;
 			vProj.SetDim(m_mOrthoBasis[m_nIteration].GetDim());
 
 			// now use GSO to make sure basis is orthogonal to already searched directions
@@ -228,7 +228,7 @@ const CVectorN<>& CConjGradOptimizer::Optimize(const CVectorN<>& vInit)
 		///////////////////////////////////////////////////////////////////////////////
 		// Update Direction
 
-		BEGIN_LOG_SECTION(CConjGradOptimizer::Optimize!Update_Direction);
+		BEGIN_LOG_SECTION(ConjGradOptimizer::Optimize!Update_Direction);
 		
 		// compute denominator for gamma
 		REAL gg = m_vGrad * m_vGrad;
@@ -285,17 +285,17 @@ const CVectorN<>& CConjGradOptimizer::Optimize(const CVectorN<>& vInit)
 		m_nIteration = -1;
 	}
 
-	END_LOG_SECTION();	// CConjGradOptimizer
+	END_LOG_SECTION();	// ConjGradOptimizer
 
 	// return the last parameter vector
 	return m_vFinalParam;
 
-}	// CConjGradOptimizer::Optimize
+}	// ConjGradOptimizer::Optimize
 
 
 //////////////////////////////////////////////////////////////////////////////
 void 
-	CConjGradOptimizer::SetAdaptiveVariance(bool bCalcVar, REAL varMin, REAL varMax)
+	ConjGradOptimizer::SetAdaptiveVariance(bool bCalcVar, REAL varMin, REAL varMax)
 	// used to set up the variance min / max calculation
 {
 	// set the flag
@@ -308,4 +308,4 @@ void
 	// set up for the objective function
 	m_pFunc->SetAdaptiveVariance(&m_vAdaptVariance, m_varMin, m_varMax);
 
-}	// CConjGradOptimizer::SetAdaptiveVariance
+}	// ConjGradOptimizer::SetAdaptiveVariance

--- a/src/OptimizeN/GradDescOptimizer.cpp
+++ b/src/OptimizeN/GradDescOptimizer.cpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////
-// CGradDescOptimizer.cpp: implementation of the CGradDescOptimizer
+// GradDescOptimizer.cpp: implementation of the GradDescOptimizer
 //
 // Copyright (C) 1996-2001
 // $Id: GradDescOptimizer.cpp,v 1.5 2005/05/12 15:55:48 HP_Administrator Exp $
@@ -23,21 +23,21 @@ const int ITER_MAX = 1500;		// maximum iteration
 
 
 //////////////////////////////////////////////////////////////////////
-// CGradDescOptimizer::CGradDescOptimizer
+// GradDescOptimizer::GradDescOptimizer
 // 
 // constructs a new gradient descent optimizer
 //////////////////////////////////////////////////////////////////////
-CGradDescOptimizer::CGradDescOptimizer(CObjectiveFunction *pFunc)
-	: COptimizer(pFunc)
+GradDescOptimizer::GradDescOptimizer(ObjectiveFunction *pFunc)
+	: Optimizer(pFunc)
 {
 }
 
 //////////////////////////////////////////////////////////////////////
-// CGradDescOptimizer::Optimize
+// GradDescOptimizer::Optimize
 // 
 // performs the optimization given the initial value vector
 //////////////////////////////////////////////////////////////////////
-const CVectorN<>& CGradDescOptimizer::Optimize(const CVectorN<>& vInit)
+const VectorN<>& GradDescOptimizer::Optimize(const VectorN<>& vInit)
 {
 	// initialize starting value
 	m_vFinalParam = vInit;

--- a/src/OptimizeN/LineFunction.cpp
+++ b/src/OptimizeN/LineFunction.cpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////
-// LineFunction.cpp: implementation of the CLineFunction
+// LineFunction.cpp: implementation of the LineFunction
 //
 // Copyright (C) 1996-2001
 // $Id: LineFunction.cpp,v 1.5 2005/03/19 20:02:49 HP_Administrator Exp $
@@ -13,44 +13,44 @@
 #include "LineFunction.h"
 
 //////////////////////////////////////////////////////////////////////
-// CLineFunction::CLineFunction
+// LineFunction::LineFunction
 // 
 // construct a new line function object, given an DIM-dimensional
 //		objective function
 //////////////////////////////////////////////////////////////////////
-CLineFunction::CLineFunction(CObjectiveFunction *pProjFunc)
-	: CObjectiveFunction(pProjFunc->HasGradientInfo()),
+LineFunction::LineFunction(ObjectiveFunction *pProjFunc)
+	: ObjectiveFunction(pProjFunc->HasGradientInfo()),
 		m_pProjFunc(pProjFunc)
 {
 }
 
 //////////////////////////////////////////////////////////////////////
-// CLineFunction::GetPoint
+// LineFunction::GetPoint
 // 
 // returns the point on the line
 //////////////////////////////////////////////////////////////////////
-const CVectorN<>& CLineFunction::GetPoint() const
+const VectorN<>& LineFunction::GetPoint() const
 {
 	return m_vPoint;
 }
 
 //////////////////////////////////////////////////////////////////////
-// CLineFunction::GetDirection
+// LineFunction::GetDirection
 // 
 // returns the direction of the line
 //////////////////////////////////////////////////////////////////////
-const CVectorN<>& CLineFunction::GetDirection() const
+const VectorN<>& LineFunction::GetDirection() const
 {
 	return m_vDirection;
 }
 
 //////////////////////////////////////////////////////////////////////
-// CLineFunction::SetLine
+// LineFunction::SetLine
 // 
 // sets the line parameters
 //////////////////////////////////////////////////////////////////////
-void CLineFunction::SetLine(const CVectorN<>& vPoint, 
-							const CVectorN<>& vDir)
+void LineFunction::SetLine(const VectorN<>& vPoint, 
+							const VectorN<>& vDir)
 {
 	ASSERT(vPoint.GetDim() == vDir.GetDim());
 
@@ -61,12 +61,12 @@ void CLineFunction::SetLine(const CVectorN<>& vPoint,
 }
 
 //////////////////////////////////////////////////////////////////////
-// CLineFunction::operator()
+// LineFunction::operator()
 // 
 // evaluates the line function
 //////////////////////////////////////////////////////////////////////
-REAL CLineFunction::operator()(const CVectorN<>& vInput, 
-							   CVectorN<> *pGrad) const
+REAL LineFunction::operator()(const VectorN<>& vInput, 
+							   VectorN<> *pGrad) const
 {
 	// ensure this is a one-dimensional input vector
 	ASSERT(vInput.GetDim() == 1);

--- a/src/OptimizeN/ObjectiveFunction.cpp
+++ b/src/OptimizeN/ObjectiveFunction.cpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////
-// ObjectiveFunction.cpp: implementation of the CObjectiveFunction 
+// ObjectiveFunction.cpp: implementation of the ObjectiveFunction 
 //		base class
 //
 // Copyright (C) 1996-2004  Derek G. Lane
@@ -15,75 +15,75 @@
 
 
 ///////////////////////////////////////////////////////////////////////////////
-// CObjectiveFunction::CObjectiveFunction
+// ObjectiveFunction::ObjectiveFunction
 // 
 // <description>
 ///////////////////////////////////////////////////////////////////////////////
-CObjectiveFunction::CObjectiveFunction(BOOL bHasGradientInfo)
+ObjectiveFunction::ObjectiveFunction(BOOL bHasGradientInfo)
 	: m_bHasGradientInfo(bHasGradientInfo)
 	, m_pAV(NULL)
 {
-}	// CObjectiveFunction::CObjectiveFunction
+}	// ObjectiveFunction::ObjectiveFunction
 
 ///////////////////////////////////////////////////////////////////////////////
-// CObjectiveFunction::HasGradientInfo
+// ObjectiveFunction::HasGradientInfo
 // 
 // whether gradient information is available
 ///////////////////////////////////////////////////////////////////////////////
-BOOL CObjectiveFunction::HasGradientInfo() const
+BOOL ObjectiveFunction::HasGradientInfo() const
 {
 	return m_bHasGradientInfo;
 
-}	// CObjectiveFunction::HasGradientInfo
+}	// ObjectiveFunction::HasGradientInfo
 
 
 ///////////////////////////////////////////////////////////////////////////////
-// CObjectiveFunction::Transform
+// ObjectiveFunction::Transform
 // 
 // over-ride for function to transform parameters
 ///////////////////////////////////////////////////////////////////////////////
-void CObjectiveFunction::Transform(CVectorN<> *pvInOut) const
+void ObjectiveFunction::Transform(VectorN<> *pvInOut) const
 {
 	// default is identity transform
 	ASSERT(false);
 
-}	// CObjectiveFunction::Transform
+}	// ObjectiveFunction::Transform
 
 ///////////////////////////////////////////////////////////////////////////////
-// CObjectiveFunction::dTransform
+// ObjectiveFunction::dTransform
 // 
 // over-ride for derivative transform parameters
 ///////////////////////////////////////////////////////////////////////////////
-void CObjectiveFunction::dTransform(CVectorN<> *pvInOut) const
+void ObjectiveFunction::dTransform(VectorN<> *pvInOut) const
 {
 	// set to all 1.0 for identity transform
 	ITERATE_VECTOR((*pvInOut), nAt, (*pvInOut)[nAt] = 1.0);
 
-}	// CObjectiveFunction::dTransform
+}	// ObjectiveFunction::dTransform
 
 ///////////////////////////////////////////////////////////////////////////////
-// CObjectiveFunction::InvTransform
+// ObjectiveFunction::InvTransform
 // 
 // inverse of parameter transform
 ///////////////////////////////////////////////////////////////////////////////
-void CObjectiveFunction::InvTransform(CVectorN<> *pvInOut) const
+void ObjectiveFunction::InvTransform(VectorN<> *pvInOut) const
 {
 	// default is identity transform
 	ASSERT(false);
 
-}	// CObjectiveFunction::InvTransform
+}	// ObjectiveFunction::InvTransform
 
 
 ///////////////////////////////////////////////////////////////////////////////
-// CObjectiveFunction::Gradient
+// ObjectiveFunction::Gradient
 // 
 // approximates gradient using difference method
 ///////////////////////////////////////////////////////////////////////////////
-void CObjectiveFunction::Gradient(const CVectorN<>& vIn, REAL epsilon, 
-				CVectorN<>& vGrad_out) const
+void ObjectiveFunction::Gradient(const VectorN<>& vIn, REAL epsilon, 
+				VectorN<>& vGrad_out) const
 {
 	REAL res = 0.0;
-	BEGIN_LOG_SECTION(CObjectiveFunction::Gradient());
+	BEGIN_LOG_SECTION(ObjectiveFunction::Gradient());
 
 	// get epsilon
 	REAL elem_max = 0.0;
@@ -94,7 +94,7 @@ void CObjectiveFunction::Gradient(const CVectorN<>& vIn, REAL epsilon,
 	epsilon = elem_max * epsilon;
 
 	// numerically evaluate the gradiant
-	CVectorN<> vParam = vIn;
+	VectorN<> vParam = vIn;
 	const REAL fp = (*this)(vParam);
 
 	vGrad_out.SetDim(vParam.GetDim());
@@ -109,25 +109,25 @@ void CObjectiveFunction::Gradient(const CVectorN<>& vIn, REAL epsilon,
 	}
 	LOG_EXPR_EXT(vGrad_out);
 
-	END_LOG_SECTION();	// CObjectiveFunction::Gradient
+	END_LOG_SECTION();	// ObjectiveFunction::Gradient
 
-}	// CObjectiveFunction::Gradient
+}	// ObjectiveFunction::Gradient
 
 
 ///////////////////////////////////////////////////////////////////////////////
-// CObjectiveFunction::Hessian
+// ObjectiveFunction::Hessian
 // 
 // approximates hessian using difference method
 ///////////////////////////////////////////////////////////////////////////////
-void CObjectiveFunction::Hessian(const CVectorN<>& vAtParam, REAL epsilon,
-								CMatrixNxM<>& mHess_out) const
+void ObjectiveFunction::Hessian(const VectorN<>& vAtParam, REAL epsilon,
+								MatrixNxM<>& mHess_out) const
 {
-	BEGIN_LOG_SECTION(CObjectiveFunction::Hessian());
+	BEGIN_LOG_SECTION(ObjectiveFunction::Hessian());
 
 	const REAL fp = (*this)(vAtParam);
 
 	// numerically evaluate the hessian
-	CVectorN<> vParam = vAtParam;
+	VectorN<> vParam = vAtParam;
 	mHess_out.Reshape(vParam.GetDim(), vParam.GetDim());
 	for (int nAtCol = 0; nAtCol < vParam.GetDim(); nAtCol++)
 	{
@@ -158,14 +158,14 @@ void CObjectiveFunction::Hessian(const CVectorN<>& vAtParam, REAL epsilon,
 	}
 	LOG_EXPR_EXT(mHess_out);
 
-	END_LOG_SECTION();	// CObjectiveFunction::Hessian
+	END_LOG_SECTION();	// ObjectiveFunction::Hessian
 
-}	// CObjectiveFunction::Hessian
+}	// ObjectiveFunction::Hessian
 
 
 //////////////////////////////////////////////////////////////////////////////
 void 
-	CObjectiveFunction::SetAdaptiveVariance(CVectorN<> *pAV, REAL varMin, REAL varMax)
+	ObjectiveFunction::SetAdaptiveVariance(VectorN<> *pAV, REAL varMin, REAL varMax)
 	// sets the OF to use adaptive variance
 {
 	// store pointer to the AV vector
@@ -175,5 +175,5 @@ void
 	m_varMin = varMin;
 	m_varMax = varMax;
 
-}	// CObjectiveFunction::SetAdaptiveVariance
+}	// ObjectiveFunction::SetAdaptiveVariance
 

--- a/src/OptimizeN/Optimizer.cpp
+++ b/src/OptimizeN/Optimizer.cpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////
-// Optimizer.cpp: implementation of the COptimizer base class
+// Optimizer.cpp: implementation of the Optimizer base class
 //
 // Copyright (C) 1996-2001
 // $Id: Optimizer.cpp,v 1.2 2004/10/09 17:03:57 default Exp $
@@ -13,11 +13,11 @@
 #include "Optimizer.h"
 
 //////////////////////////////////////////////////////////////////////
-// COptimizer::COptimizer
+// Optimizer::Optimizer
 // 
 // base class for all optimizers
 //////////////////////////////////////////////////////////////////////
-COptimizer::COptimizer(CObjectiveFunction *pFunc)
+Optimizer::Optimizer(ObjectiveFunction *pFunc)
 	: m_tolerance(0.5f),
 		m_nIteration(0),
 		m_pFunc(pFunc),
@@ -25,115 +25,115 @@ COptimizer::COptimizer(CObjectiveFunction *pFunc)
 		m_pCallbackParam(NULL),
 		m_bUseGradientInfo(FALSE)
 {
-}	// COptimizer::COptimizer
+}	// Optimizer::Optimizer
 
 
 //////////////////////////////////////////////////////////////////////
-// COptimizer::~COptimizer
+// Optimizer::~Optimizer
 // 
 // destroy the optimizer
 //////////////////////////////////////////////////////////////////////
-COptimizer::~COptimizer()
+Optimizer::~Optimizer()
 {
-}	// COptimizer::~COptimizer
+}	// Optimizer::~Optimizer
 
 
 ///////////////////////////////////////////////////////////////////////////////
-// COptimizer::SetCallback
+// Optimizer::SetCallback
 // 
 // sets the callback function
 ///////////////////////////////////////////////////////////////////////////////
-void COptimizer::SetCallback(OptimizerCallback *pCallback, void *pParam)
+void Optimizer::SetCallback(OptimizerCallback *pCallback, void *pParam)
 {
 	m_pCallbackFunc = pCallback;
 	m_pCallbackParam = pParam;
 
-}	// COptimizer::SetCallback
+}	// Optimizer::SetCallback
 
 
 //////////////////////////////////////////////////////////////////////
-// COptimizer::UseGradientInfo
+// Optimizer::UseGradientInfo
 // 
 // returns the flag to indicate that gradient information should
 //		be used
 //////////////////////////////////////////////////////////////////////
-BOOL COptimizer::UseGradientInfo() const
+BOOL Optimizer::UseGradientInfo() const
 {
 	return m_bUseGradientInfo;
 
-}	// COptimizer::UseGradientInfo
+}	// Optimizer::UseGradientInfo
 
 
 //////////////////////////////////////////////////////////////////////
-// COptimizer::SetUseGradientInfo
+// Optimizer::SetUseGradientInfo
 // 
 // sets the flag to indicate that gradient information should
 //		be used
 //////////////////////////////////////////////////////////////////////
-void COptimizer::SetUseGradientInfo(BOOL bUseGradientInfo)
+void Optimizer::SetUseGradientInfo(BOOL bUseGradientInfo)
 {
 	m_bUseGradientInfo = bUseGradientInfo;
 
-}	// COptimizer::SetUseGradientInfo
+}	// Optimizer::SetUseGradientInfo
 
 
 //////////////////////////////////////////////////////////////////////
-// COptimizer::GetTolerance
+// Optimizer::GetTolerance
 // 
 // returns the tolerance for exit from optimization loop
 //////////////////////////////////////////////////////////////////////
-REAL COptimizer::GetTolerance() const
+REAL Optimizer::GetTolerance() const
 {
 	return m_tolerance;
 
-}	// COptimizer::GetTolerance
+}	// Optimizer::GetTolerance
 
 
 //////////////////////////////////////////////////////////////////////
-// COptimizer::SetTolerance
+// Optimizer::SetTolerance
 // 
 // sets the tolerance for exit from optimization loop
 //////////////////////////////////////////////////////////////////////
-void COptimizer::SetTolerance(REAL tol)
+void Optimizer::SetTolerance(REAL tol)
 {
 	m_tolerance = tol;
 
-}	// COptimizer::SetTolerance
+}	// Optimizer::SetTolerance
 
 
 //////////////////////////////////////////////////////////////////////
-// COptimizer::GetIterations
+// Optimizer::GetIterations
 // 
 // returns the number of iterations needed for the previous 
 //		optimization
 //////////////////////////////////////////////////////////////////////
-int COptimizer::GetIterations() const
+int Optimizer::GetIterations() const
 {
 	return m_nIteration;
 
-}	// COptimizer::GetIterations
+}	// Optimizer::GetIterations
 
 
 //////////////////////////////////////////////////////////////////////
-// COptimizer::GetFinalValue
+// Optimizer::GetFinalValue
 // 
 // holds the final value of the optimization
 //////////////////////////////////////////////////////////////////////
-REAL COptimizer::GetFinalValue() const
+REAL Optimizer::GetFinalValue() const
 {
 	return m_finalValue;
 
-}	// COptimizer::GetFinalValue
+}	// Optimizer::GetFinalValue
 
 
 //////////////////////////////////////////////////////////////////////
-// COptimizer::GetFinalParameter
+// Optimizer::GetFinalParameter
 // 
 // holds the final value of the parameters for the minimum f
 //////////////////////////////////////////////////////////////////////
-const CVectorN<>& COptimizer::GetFinalParameter() const
+const VectorN<>& Optimizer::GetFinalParameter() const
 {
 	return m_vFinalParam;
 
-}	// COptimizer::GetFinalParameter
+}	// Optimizer::GetFinalParameter
 

--- a/src/OptimizeN/PowellOptimizer.cpp
+++ b/src/OptimizeN/PowellOptimizer.cpp
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////
-// PowellOptimizer.cpp: implementation of the CBrentOptimizer
+// PowellOptimizer.cpp: implementation of the BrentOptimizer
 //
 // Copyright (C) 1996-2001
 // $Id: PowellOptimizer.cpp,v 1.8 2007/05/09 01:53:42 Derek Lane Exp $
@@ -15,39 +15,39 @@
 const int ITER_MAX = 1000;		// maximum iteration
 
 //////////////////////////////////////////////////////////////////////
-// CPowellOptimizer::CPowellOptimizer
+// PowellOptimizer::PowellOptimizer
 // 
 // performs the optimization given the initial value vector
 //////////////////////////////////////////////////////////////////////
-CPowellOptimizer::CPowellOptimizer(CObjectiveFunction *pFunc)
-	: COptimizer(pFunc),
+PowellOptimizer::PowellOptimizer(ObjectiveFunction *pFunc)
+	: Optimizer(pFunc),
 		m_lineFunction(pFunc),
 		m_optimizeBrent(&m_lineFunction)
 {
 	// set the Brent optimizer to not use the gradient information
 	m_optimizeBrent.SetUseGradientInfo(FALSE);
 
-}	// CPowellOptimizer::CPowellOptimizer
+}	// PowellOptimizer::PowellOptimizer
 
 
 //////////////////////////////////////////////////////////////////////
-// CPowellOptimizer::~CPowellOptimizer
+// PowellOptimizer::~PowellOptimizer
 // 
 // destroy the optimizer
 //////////////////////////////////////////////////////////////////////
-CPowellOptimizer::~CPowellOptimizer()
+PowellOptimizer::~PowellOptimizer()
 {
-}	// CPowellOptimizer::~CPowellOptimizer
+}	// PowellOptimizer::~PowellOptimizer
 
 
 //////////////////////////////////////////////////////////////////////
-// CPowellOptimizer::Optimize
+// PowellOptimizer::Optimize
 // 
 // performs the optimization given the initial value vector
 //////////////////////////////////////////////////////////////////////
-const CVectorN<>& CPowellOptimizer::Optimize(const CVectorN<>& vInit)
+const VectorN<>& PowellOptimizer::Optimize(const VectorN<>& vInit)
 {
-	BEGIN_LOG_SECTION(CPowellOptimizer::Optimize);
+	BEGIN_LOG_SECTION(PowellOptimizer::Optimize);
 
 	LOG_EXPR_EXT(vInit);
 	LOG_EXPR(GetTolerance());
@@ -84,13 +84,13 @@ const CVectorN<>& CPowellOptimizer::Optimize(const CVectorN<>& vInit)
 		if (2.0 * fabs(fp - m_finalValue) >
 			m_optimizeBrent.GetTolerance() * (fabs(fp) + fabs(m_finalValue)))
 		{
-			// static CVectorN<> ptt = 2.0f * m_vFinalParam - pt;
+			// static VectorN<> ptt = 2.0f * m_vFinalParam - pt;
 			m_vPtt = m_vFinalParam;
 			m_vPtt *= (REAL) 2.0;
 			m_vPtt -= m_vPt;
 			LOG_EXPR_EXT_DESC(m_vPtt, "m_vPtt = 2.0 * m_vFinalParam - m_vPt");
 
-			// static CVectorN<> xit = m_vFinalParam - pt;
+			// static VectorN<> xit = m_vFinalParam - pt;
 			m_vXit = m_vFinalParam;
 			m_vXit -= m_vPt;
 			LOG_EXPR_EXT_DESC(m_vXit, "m_vXit = m_vFinalParam - m_vPt");
@@ -117,27 +117,27 @@ const CVectorN<>& CPowellOptimizer::Optimize(const CVectorN<>& vInit)
 		END_LOG_SECTION();	// Iteration
 	}
 	
-	END_LOG_SECTION();	// CPowellOptimizer::Optimize
+	END_LOG_SECTION();	// PowellOptimizer::Optimize
 
 	return m_vFinalParam;
 
-}	// CPowellOptimizer::Optimize
+}	// PowellOptimizer::Optimize
 
 
 
 //////////////////////////////////////////////////////////////////////
-// CPowellOptimizer::IterateOverDirectionSet
+// PowellOptimizer::IterateOverDirectionSet
 // 
 // iterates over direction set once, returning the direction of
 //		biggest change
 // 
 //////////////////////////////////////////////////////////////////////
-int CPowellOptimizer::IterateOverDirectionSet(REAL &del)
+int PowellOptimizer::IterateOverDirectionSet(REAL &del)
 {
 	int nBigDir = 0;
 	del = 0.0;
 
-	BEGIN_LOG_SECTION_("CPowellOptimizer::IterateOverDirectionSet");
+	BEGIN_LOG_SECTION_("PowellOptimizer::IterateOverDirectionSet");
 
 	// in each iteration, loop over all directions in the set
 	int nDim = m_mDirections.GetCols();
@@ -154,7 +154,7 @@ int CPowellOptimizer::IterateOverDirectionSet(REAL &del)
 		LOG_EXPR_EXT_DESC(m_mDirections[nAtDir], "Line direction");
 
 		// now launch a Brent optimization
-		REAL lambda = m_optimizeBrent.Optimize(CBrentOptimizer::GetInitZero())[0];
+		REAL lambda = m_optimizeBrent.Optimize(BrentOptimizer::GetInitZero())[0];
 		LOG_EXPR(lambda);
 
 		// set the final value
@@ -162,7 +162,7 @@ int CPowellOptimizer::IterateOverDirectionSet(REAL &del)
 
 		// update the current point
 		// m_vFinalParam += lambda * m_lineFunction.GetDirection();
-		// static CVectorN<> m_vScaledDir;
+		// static VectorN<> m_vScaledDir;
 		m_vScaledDir = m_lineFunction.GetDirection();
 		m_vScaledDir *= (fabs(lambda) > DEFAULT_EPSILON) 
 			? lambda : DEFAULT_EPSILON;
@@ -186,17 +186,17 @@ int CPowellOptimizer::IterateOverDirectionSet(REAL &del)
 
 	return nBigDir;
 
-}	// CPowellOptimizer::IterateOverDirectionSet
+}	// PowellOptimizer::IterateOverDirectionSet
 
 
 //////////////////////////////////////////////////////////////////////
-// CPowellOptimizer::FindNewDirection
+// PowellOptimizer::FindNewDirection
 // 
 // determines a new direction to add to the direction set
 //////////////////////////////////////////////////////////////////////
-void CPowellOptimizer::FindNewDirection(REAL fp, REAL fptt, REAL del, int nBigDir)
+void PowellOptimizer::FindNewDirection(REAL fp, REAL fptt, REAL del, int nBigDir)
 {
-	BEGIN_LOG_SECTION_("CPowellOptimizer::FindNewDirection");
+	BEGIN_LOG_SECTION_("PowellOptimizer::FindNewDirection");
 
 	// compute the t parameter to determine the brent optimization parameter
 	REAL t = (REAL) 2.0 
@@ -214,7 +214,7 @@ void CPowellOptimizer::FindNewDirection(REAL fp, REAL fptt, REAL del, int nBigDi
 		LOG_EXPR_EXT_DESC(m_vXit, "Line direction (t &lt; 0.0)");
 
 		// now launch a Brent optimization
-		REAL lambda = m_optimizeBrent.Optimize(CBrentOptimizer::GetInitZero())[0];
+		REAL lambda = m_optimizeBrent.Optimize(BrentOptimizer::GetInitZero())[0];
 		LOG_EXPR(lambda);
 
 		// update the current point
@@ -237,5 +237,5 @@ void CPowellOptimizer::FindNewDirection(REAL fp, REAL fptt, REAL del, int nBigDi
 
 	END_LOG_SECTION();
 
-}	// CPowellOptimizer::FindNewDirection
+}	// PowellOptimizer::FindNewDirection
 

--- a/src/OptimizeN/include/BrentOptimizer.h
+++ b/src/OptimizeN/include/BrentOptimizer.h
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////
-// BrentOptimizer.h: interface for the CBrentOptimizer
+// BrentOptimizer.h: interface for the BrentOptimizer
 //
 // Copyright (C) 1996-2001
 // $Id: BrentOptimizer.h,v 1.2 2004/02/16 15:55:22 default Exp $
@@ -13,23 +13,23 @@
 #include "Optimizer.h"
 
 //////////////////////////////////////////////////////////////////////
-// class CBrentOptimizer
+// class BrentOptimizer
 // 
 // optimizer that implements the Brent algorithm explained in
 //		Numerical Recipes
 //////////////////////////////////////////////////////////////////////
-class CBrentOptimizer : public COptimizer
+class BrentOptimizer : public Optimizer
 {
 public:
 	void SetParams(REAL Bracket, REAL GLimit);
 	// construct a new Brent Optimizer
-	CBrentOptimizer(CObjectiveFunction *pFunc);
+	BrentOptimizer(ObjectiveFunction *pFunc);
 
 	// optimizes the initial input vector
-	virtual const CVectorN<>& Optimize(const CVectorN<>& vInit = m_vBrentInit);
+	virtual const VectorN<>& Optimize(const VectorN<>& vInit = m_vBrentInit);
 
 	// helper function to return an initial Zero vector
-	static const CVectorN<>& GetInitZero();
+	static const VectorN<>& GetInitZero();
 
 protected:
 	// finds a bracket for the minimum value of the objective function
@@ -44,11 +44,11 @@ protected:
 private:
 	// these are "local" variables that are initialized here so that we do not
 	//		need to re-allocate them during optimization
-	CVectorN<> m_vAx, m_vBx, m_vCx;
-	CVectorN<> m_vX, m_vU;
+	VectorN<> m_vAx, m_vBx, m_vCx;
+	VectorN<> m_vX, m_vU;
 
 	// holds the gradient
-	CVectorN<> m_vGrad;
+	VectorN<> m_vGrad;
 
 	// parameters for optimization 
 	REAL m_Bracket;	// initial bracket size
@@ -56,7 +56,10 @@ private:
 
 	// starting value for the brent optimizer
 	//		initialized to 
-	static CVectorN<> m_vBrentInit;
+	static VectorN<> m_vBrentInit;
 };
+
+// Backward compatibility
+using CBrentOptimizer = BrentOptimizer;
 
 #endif

--- a/src/OptimizeN/include/ConjGradOptimizer.h
+++ b/src/OptimizeN/include/ConjGradOptimizer.h
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////
-// ConjGradOptimizer.h: interface for the CConjGradOptimizer
+// ConjGradOptimizer.h: interface for the ConjGradOptimizer
 //
 // Copyright (C) 1996-2001
 // $Id: ConjGradOptimizer.h,v 1.10 2007/05/09 01:45:20 Derek Lane Exp $
@@ -23,22 +23,22 @@
 
 
 //////////////////////////////////////////////////////////////////////
-// class CConjGradOptimizer
+// class ConjGradOptimizer
 // 
 // optimizer that implements the Powell algorithm explained in
 //		Numerical Recipes
 //////////////////////////////////////////////////////////////////////
-class CConjGradOptimizer : public COptimizer
+class ConjGradOptimizer : public Optimizer
 {
 public:
 	// construct a gradient optimizer for an objective function
-	CConjGradOptimizer(CObjectiveFunction *pFunc);
+	ConjGradOptimizer(ObjectiveFunction *pFunc);
 
 	// returns a reference to the embedded Brent optimizer
-	CBrentOptimizer& GetBrentOptimizer();
+	BrentOptimizer& GetBrentOptimizer();
 
 	// optimize the objective function
-	virtual const CVectorN<>& Optimize(const CVectorN<>& vInit);
+	virtual const VectorN<>& Optimize(const VectorN<>& vInit);
 
 	// flag to indicate that line opt tolerance should always be same
 	DECLARE_ATTRIBUTE(LineToleranceEqual, bool);
@@ -49,20 +49,20 @@ public:
 private:
 	// line function that projects the objective function along 
 	//		a given line
-	CLineFunction m_lineFunction;
+	LineFunction m_lineFunction;
 
 	// points to the line optimizer to be used
-	COptimizer *m_pLineOptimizer;
+	Optimizer *m_pLineOptimizer;
 
 	// brent optimizer along the line function
-	CBrentOptimizer m_optimizeBrent;
+	BrentOptimizer m_optimizeBrent;
 
 	// "statics" for the optimization routine
-	CVectorN<> m_vGrad;
-	CVectorN<> m_vGradPrev;
-	CVectorN<> m_vDir;
-	CVectorN<> m_vDirPrev;
-	CVectorN<> m_vLambdaScaled;
+	VectorN<> m_vGrad;
+	VectorN<> m_vGradPrev;
+	VectorN<> m_vDir;
+	VectorN<> m_vDirPrev;
+	VectorN<> m_vLambdaScaled;
 
 	// flag to indicate adaptive variance calculation
 	bool m_bCalcVar;
@@ -72,12 +72,15 @@ private:
 	REAL m_varMax;
 
 	// stores orthogonal basis for searched directions (used to calculate adaptive variance)
-	CMatrixNxM<> m_mOrthoBasis;
+	MatrixNxM<> m_mOrthoBasis;
 
 	// stores the calculated AV
-	CVectorN<> m_vAdaptVariance;
+	VectorN<> m_vAdaptVariance;
 
-};	// class CConjGradOptimizer
+};	// class ConjGradOptimizer
 
+
+// Backward compatibility
+using CConjGradOptimizer = ConjGradOptimizer;
 
 #endif

--- a/src/OptimizeN/include/GradDescOptimizer.h
+++ b/src/OptimizeN/include/GradDescOptimizer.h
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////
-// GradDescOptimizer.h: interface for the CGradDescOptimizer
+// GradDescOptimizer.h: interface for the GradDescOptimizer
 //
 // Copyright (C) 1996-2001
 // $Id: GradDescOptimizer.h,v 1.1 2002/06/11 04:01:01 default Exp $
@@ -13,22 +13,25 @@
 #include "Optimizer.h"
 
 //////////////////////////////////////////////////////////////////////
-// class CGradDescOptimizer
+// class GradDescOptimizer
 // 
 // optimizer that implements 1D gradient optimizer
 //////////////////////////////////////////////////////////////////////
-class CGradDescOptimizer : public COptimizer
+class GradDescOptimizer : public Optimizer
 {
 public:
 	// construct a new Gradient Descent Optimizer
-	CGradDescOptimizer(CObjectiveFunction *pFunc);
+	GradDescOptimizer(ObjectiveFunction *pFunc);
 
 	// optimizes the initial input vector
-	virtual const CVectorN<>& Optimize(const CVectorN<>& vInit);
+	virtual const VectorN<>& Optimize(const VectorN<>& vInit);
 
 private:
 	// holds the gradient
-	CVectorN<> m_vGrad;
+	VectorN<> m_vGrad;
 };
+
+// Backward compatibility
+using CGradDescOptimizer = GradDescOptimizer;
 
 #endif

--- a/src/OptimizeN/include/LineFunction.h
+++ b/src/OptimizeN/include/LineFunction.h
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////
-// LineFunction.h: interface for the CLineFunction
+// LineFunction.h: interface for the LineFunction
 //
 // Copyright (C) 1996-2001
 // $Id: LineFunction.h,v 1.3 2004/02/16 15:56:09 default Exp $
@@ -13,47 +13,50 @@
 #include "ObjectiveFunction.h"
 
 //////////////////////////////////////////////////////////////////////
-// class CLineFunction
+// class LineFunction
 // 
 // defines a line function given another objective function and
 //		a line in the vector-space domain of that objective function
 //////////////////////////////////////////////////////////////////////
-class CLineFunction : public CObjectiveFunction
+class LineFunction : public ObjectiveFunction
 {
 public:
 	// construct a new line function object, given an DIM-dimensional
 	//		objective function
-	CLineFunction(CObjectiveFunction *pProjFunc);
+	LineFunction(ObjectiveFunction *pProjFunc);
 
 	// returns the point on the line
-	const CVectorN<>& GetPoint() const;
+	const VectorN<>& GetPoint() const;
 
 	// returns the direction of the line
-	const CVectorN<>& GetDirection() const;
+	const VectorN<>& GetDirection() const;
 
 	// sets the line parameters
-	void SetLine(const CVectorN<>& vPoint, const CVectorN<>& vDir);
+	void SetLine(const VectorN<>& vPoint, const VectorN<>& vDir);
 
 	// evaluates the line function
-	virtual REAL operator()(const CVectorN<>& vInput,
-		CVectorN<> *pGrad = NULL) const;
+	virtual REAL operator()(const VectorN<>& vInput,
+		VectorN<> *pGrad = NULL) const;
 
 private:
 	// pointer to the objective function upon which this line function
 	//		is based
-	CObjectiveFunction *m_pProjFunc;
+	ObjectiveFunction *m_pProjFunc;
 
 	// stores a point on the line
-	CVectorN<> m_vPoint;
+	VectorN<> m_vPoint;
 
 	// stores the direction of the line
-	CVectorN<> m_vDirection;
+	VectorN<> m_vDirection;
 
 	// temporary store of evaluation point
-	mutable CVectorN<> m_vEvalPoint;
+	mutable VectorN<> m_vEvalPoint;
 
 	// stores the gradient at the last evaluated point
-	mutable CVectorN<> m_vGrad;
+	mutable VectorN<> m_vGrad;
 };
+
+// Backward compatibility
+using CLineFunction = LineFunction;
 
 #endif

--- a/src/OptimizeN/include/MatrixNxM.h
+++ b/src/OptimizeN/include/MatrixNxM.h
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////
-// MatrixNxM.h: declaration and definition of the CMatrixNxM template class.
+// MatrixNxM.h: declaration and definition of the MatrixNxM template class.
 //
 // Copyright (C) 1999-2006 Derek G Lane
 // $Id: MatrixNxM.h,v 1.1 2007/05/09 01:45:49 Derek Lane Exp $
@@ -12,12 +12,12 @@
 #include "MatrixOps.h"
 
 //////////////////////////////////////////////////////////////////////
-// class CMatrixNxM<TYPE>
+// class MatrixNxM<TYPE>
 //
 // represents a non-square matrix with type given.
 //////////////////////////////////////////////////////////////////////
 template<class TYPE = REAL>
-class CMatrixNxM
+class MatrixNxM
 {
 	// counts number of columns
 	int m_nColumns;
@@ -33,13 +33,13 @@ class CMatrixNxM
 
 public:
 	// constructors / destructor
-	CMatrixNxM();
-	explicit CMatrixNxM(int nCols, int nRows);
-	CMatrixNxM(const CMatrixNxM& fromMatrix);
-	~CMatrixNxM();
+	MatrixNxM();
+	explicit MatrixNxM(int nCols, int nRows);
+	MatrixNxM(const MatrixNxM& fromMatrix);
+	~MatrixNxM();
 
 	// assignment operator
-	CMatrixNxM& operator=(const CMatrixNxM<TYPE>& fromMatrix);
+	MatrixNxM& operator=(const MatrixNxM<TYPE>& fromMatrix);
 
 	// SetIdentity -- sets the matrix to an identity matrix
 	void SetIdentity();
@@ -67,13 +67,13 @@ public:
 
 	// IsApproxEqual -- tests for approximate equality using the EPS
 	//		defined at the top of this file
-	bool IsApproxEqual(const CMatrixNxM& m, TYPE epsilon = DEFAULT_EPSILON) const;
+	bool IsApproxEqual(const MatrixNxM& m, TYPE epsilon = DEFAULT_EPSILON) const;
 
 	// in-place operators
-	CMatrixNxM& operator+=(const CMatrixNxM& mRight);
-	CMatrixNxM& operator-=(const CMatrixNxM& mRight);
-	CMatrixNxM& operator*=(const TYPE& scale);
-	CMatrixNxM& operator*=(const CMatrixNxM& mRight);
+	MatrixNxM& operator+=(const MatrixNxM& mRight);
+	MatrixNxM& operator-=(const MatrixNxM& mRight);
+	MatrixNxM& operator*=(const TYPE& scale);
+	MatrixNxM& operator*=(const MatrixNxM& mRight);
 
 	// Transpose -- transposes elements of the matrix
 	void Transpose();
@@ -90,24 +90,24 @@ protected:
 	// SetElements -- sets the elements to an external pointer
 	void SetElements(int nCols, int nRows, TYPE *pElements, bool bFreeElements);
 
-};	// class CMatrixNxM
+};	// class MatrixNxM
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CMatrixNxM<TYPE>::CMatrixNxM()
+MatrixNxM<TYPE>::MatrixNxM()
 	// default constructor -- initializes to 0x0 matrix
 	: m_nColumns(0),
 		m_pColumns(NULL),
 		m_pElements(NULL),
 		m_bFreeElements(TRUE)
 {
-}	// CMatrixNxM<TYPE>::CMatrixNxM<TYPE>
+}	// MatrixNxM<TYPE>::MatrixNxM<TYPE>
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CMatrixNxM<TYPE>::CMatrixNxM(int nCols, int nRows)
+MatrixNxM<TYPE>::MatrixNxM(int nCols, int nRows)
 	// constructs a specific-dimensioned matrix
 	: m_nColumns(0),
 		m_pColumns(NULL),
@@ -116,12 +116,12 @@ CMatrixNxM<TYPE>::CMatrixNxM(int nCols, int nRows)
 {
 	Reshape(nCols, nRows);
 
-}	// CMatrixNxM<TYPE>::CMatrixNxM<TYPE>(int nCols, int nRows)
+}	// MatrixNxM<TYPE>::MatrixNxM<TYPE>(int nCols, int nRows)
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CMatrixNxM<TYPE>::CMatrixNxM(const CMatrixNxM<TYPE>& fromMatrix)
+MatrixNxM<TYPE>::MatrixNxM(const MatrixNxM<TYPE>& fromMatrix)
 	// copy constructor
 	: m_nColumns(0),
 		m_pColumns(NULL),
@@ -133,25 +133,25 @@ CMatrixNxM<TYPE>::CMatrixNxM(const CMatrixNxM<TYPE>& fromMatrix)
 
 	(*this) = fromMatrix;
 
-}	// CMatrixNxM<TYPE>::CMatrixNxM<TYPE>(
-	//		const CMatrixNxM<TYPE>& fromMatrix)
+}	// MatrixNxM<TYPE>::MatrixNxM<TYPE>(
+	//		const MatrixNxM<TYPE>& fromMatrix)
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CMatrixNxM<TYPE>::~CMatrixNxM()
+MatrixNxM<TYPE>::~MatrixNxM()
 	// destructor
 {
 	// frees any elements, if needed
 	SetElements(0, 0, NULL, TRUE);
 
-}	// CMatrixNxM<TYPE>::~CMatrixNxM<TYPE>
+}	// MatrixNxM<TYPE>::~MatrixNxM<TYPE>
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CMatrixNxM<TYPE>& 
-	CMatrixNxM<TYPE>::operator=(const CMatrixNxM<TYPE>& fromMatrix)
+MatrixNxM<TYPE>& 
+	MatrixNxM<TYPE>::operator=(const MatrixNxM<TYPE>& fromMatrix)
 	// assignment operator
 {
 	// checks the dimensions
@@ -166,13 +166,13 @@ CMatrixNxM<TYPE>&
 
 	return (*this);
 
-}	// CMatrixNxM<TYPE>::operator=
+}	// MatrixNxM<TYPE>::operator=
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
 void 
-	CMatrixNxM<TYPE>::SetIdentity()
+	MatrixNxM<TYPE>::SetIdentity()
 	// sets the matrix to an identity matrix
 {
 	ZeroValues(&(*this)[0][0], GetRows() * GetCols());
@@ -189,7 +189,7 @@ void
 //////////////////////////////////////////////////////////////////
 template<class TYPE>
 void 
-	CMatrixNxM<TYPE>::Reshape(int nCols, int nRows, bool bPreserve)
+	MatrixNxM<TYPE>::Reshape(int nCols, int nRows, bool bPreserve)
 	// sets the dimension of the matrix
 {
 	// check if we need to reshape
@@ -234,7 +234,7 @@ void
 		ZeroValues(pNewElements, nCols * nRows);
 
 		// create a temporary matrix to hold the old elements
-		CMatrixNxM<TYPE> mTemp;
+		MatrixNxM<TYPE> mTemp;
 		mTemp.SetElements(nOldCols, nOldRows, pOldElements, TRUE);
 
 		// and assign
@@ -252,13 +252,13 @@ void
 		SetIdentity();
 	}
 
-}	// CMatrixNxM<TYPE>::Reshape
+}	// MatrixNxM<TYPE>::Reshape
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
 CVectorN<TYPE>& 
-	CMatrixNxM<TYPE>::operator[](int nAtCol)
+	MatrixNxM<TYPE>::operator[](int nAtCol)
 	// retrieves a reference to a column vector
 {
 	// bounds check on the index
@@ -267,13 +267,13 @@ CVectorN<TYPE>&
 	// return a reference to the column vector
 	return m_pColumns[nAtCol];
 
-}	// CMatrixNxM<TYPE>::operator[]
+}	// MatrixNxM<TYPE>::operator[]
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
 const CVectorN<TYPE>& 
-	CMatrixNxM<TYPE>::operator[](int nAtCol) const
+	MatrixNxM<TYPE>::operator[](int nAtCol) const
 	// retrieves a reference to a column vector
 {
 	// bounds check on the index
@@ -282,24 +282,24 @@ const CVectorN<TYPE>&
 	// return a reference to the column vector
 	return m_pColumns[nAtCol];
 
-}	// CMatrixNxM<TYPE>::operator[]
+}	// MatrixNxM<TYPE>::operator[]
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
 int 
-	CMatrixNxM<TYPE>::GetCols() const
+	MatrixNxM<TYPE>::GetCols() const
 	// returns the number of columns of the matrix
 {
 	return m_nColumns;
 
-}	// CMatrixNxM<TYPE>::GetCols
+}	// MatrixNxM<TYPE>::GetCols
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
 int 
-	CMatrixNxM<TYPE>::GetRows() const
+	MatrixNxM<TYPE>::GetRows() const
 	// returns the number of rows of the matrix
 {
 	if (m_pColumns)
@@ -309,37 +309,37 @@ int
 
 	return 0;
 
-}	// CMatrixNxM<TYPE>::GetRows
+}	// MatrixNxM<TYPE>::GetRows
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CMatrixNxM<TYPE>::operator TYPE *()
+MatrixNxM<TYPE>::operator TYPE *()
 	// TYPE * conversion -- returns a pointer to the first element
 	//		WARNING: this allows for no-bounds-checking access
 
 {
 	return &m_pElements[0];
 
-}	// CMatrixNxM<TYPE>::operator TYPE *
+}	// MatrixNxM<TYPE>::operator TYPE *
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CMatrixNxM<TYPE>::operator const TYPE *() const
+MatrixNxM<TYPE>::operator const TYPE *() const
 	// const TYPE * conversion -- returns a pointer to the first 
 	//		element.
 	//		WARNING: this allows for no-bounds-checking access
 {
 	return &m_pElements[0];
 
-}	// CMatrixNxM<TYPE>::operator const TYPE *
+}	// MatrixNxM<TYPE>::operator const TYPE *
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE>
 void 
-	CMatrixNxM<TYPE>::GetRow(int nAtRow, CVectorN<TYPE>& vRow) const
+	MatrixNxM<TYPE>::GetRow(int nAtRow, CVectorN<TYPE>& vRow) const
 	// constructs and returns a row vector
 {
 	// make the row vector the same size
@@ -351,13 +351,13 @@ void
 		vRow[nAtCol] = (*this)[nAtCol][nAtRow];
 	}
 
-}	// CMatrixNxM<TYPE>::GetRow
+}	// MatrixNxM<TYPE>::GetRow
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE>
 void 
-	CMatrixNxM<TYPE>::SetRow(int nAtRow, const CVectorN<TYPE>& vRow)
+	MatrixNxM<TYPE>::SetRow(int nAtRow, const CVectorN<TYPE>& vRow)
 	// sets the rows vector
 {
 	if (vRow.GetDim() == GetCols())
@@ -369,13 +369,13 @@ void
 		}
 	}
 
-}	// CMatrixNxM<TYPE>::SetRow
+}	// MatrixNxM<TYPE>::SetRow
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
 bool 
-	CMatrixNxM<TYPE>::IsApproxEqual(const CMatrixNxM& m, TYPE epsilon) const
+	MatrixNxM<TYPE>::IsApproxEqual(const MatrixNxM& m, TYPE epsilon) const
 	// tests for approximate equality using the EPS 
 {
 	ASSERT(GetCols() == m.GetCols());
@@ -390,13 +390,13 @@ bool
 
 	return TRUE;
 
-}	// CMatrixNxM<TYPE>::IsApproxEqual
+}	// MatrixNxM<TYPE>::IsApproxEqual
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CMatrixNxM<TYPE>& 
-	CMatrixNxM<TYPE>::operator+=(const CMatrixNxM<TYPE>& mRight)
+MatrixNxM<TYPE>& 
+	MatrixNxM<TYPE>::operator+=(const MatrixNxM<TYPE>& mRight)
 	// in-place matrix addition; returns a reference to this
 {
 	ASSERT(GetCols() == mRight.GetCols());
@@ -407,13 +407,13 @@ CMatrixNxM<TYPE>&
 	// return a reference to this
 	return (*this);
 
-}	// CMatrixNxM<TYPE>::operator+=
+}	// MatrixNxM<TYPE>::operator+=
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CMatrixNxM<TYPE>& 
-	CMatrixNxM<TYPE>::operator-=(const CMatrixNxM<TYPE>& mRight)
+MatrixNxM<TYPE>& 
+	MatrixNxM<TYPE>::operator-=(const MatrixNxM<TYPE>& mRight)
 	// in-place matrix subtraction; returns a reference to 	this
 {
 	ASSERT(GetCols() == mRight.GetCols());
@@ -424,16 +424,16 @@ CMatrixNxM<TYPE>&
 	// return a reference to this
 	return (*this);
 
-}	// CMatrixNxM<TYPE>::operator-=
+}	// MatrixNxM<TYPE>::operator-=
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CMatrixNxM<TYPE>& 
-	CMatrixNxM<TYPE>::operator*=(const CMatrixNxM<TYPE>& mRight)
+MatrixNxM<TYPE>& 
+	MatrixNxM<TYPE>::operator*=(const MatrixNxM<TYPE>& mRight)
 	// in-place matrix multiplication; returns a reference to this
 {
-	CMatrixNxM<TYPE> mProduct = (*this) * mRight;
+	MatrixNxM<TYPE> mProduct = (*this) * mRight;
 
 	// and assign
 	Reshape(mProduct.GetCols(), mProduct.GetRows());
@@ -442,13 +442,13 @@ CMatrixNxM<TYPE>&
 	// return a reference to this
 	return (*this);
 
-}	// CMatrixNxM<TYPE>::operator*=
+}	// MatrixNxM<TYPE>::operator*=
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CMatrixNxM<TYPE>& 
-	CMatrixNxM<TYPE>::operator*=(const TYPE& scale)
+MatrixNxM<TYPE>& 
+	MatrixNxM<TYPE>::operator*=(const TYPE& scale)
 	// in-place matrix multiplication; returns a reference to this
 {
 	MultValues(&(*this)[0][0], scale, GetCols() * GetRows());
@@ -456,13 +456,13 @@ CMatrixNxM<TYPE>&
 	// return a reference to this
 	return (*this);
 
-}	// CMatrixNxM<TYPE>::operator*=
+}	// MatrixNxM<TYPE>::operator*=
 
 
 //////////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
 void 
-	CMatrixNxM<TYPE>::Transpose()
+	MatrixNxM<TYPE>::Transpose()
 	// transposes the matrix
 {
 	// allocate the elements of the transposed matrix
@@ -470,7 +470,7 @@ void
 	AllocValues(GetRows() * GetCols(), pElements);
 
 	// make the transposed matrix
-	CMatrixNxM<TYPE> mTranspose;
+	MatrixNxM<TYPE> mTranspose;
 	mTranspose.SetElements(GetRows(), GetCols(), pElements, FALSE);
 	
 	for (int nCol = 0; nCol < GetCols(); nCol++)
@@ -492,7 +492,7 @@ void
 //////////////////////////////////////////////////////////////////////
 template<> INLINE									
 void 
-	CMatrixNxM<float>::Transpose()					
+	MatrixNxM<float>::Transpose()					
 	// transposes the matrix
 {													
 	float *pElements = NULL;							
@@ -505,12 +505,12 @@ void
 
 	SetElements(GetRows(), GetCols(), pElements, true);
 
-}	// CMatrixNxM<TYPE>::Transpose
+}	// MatrixNxM<TYPE>::Transpose
 
 //////////////////////////////////////////////////////////////////////
 template<> INLINE									
 void 
-	CMatrixNxM<double>::Transpose()					
+	MatrixNxM<double>::Transpose()					
 	// transposes the matrix
 {							
 	double *pElements = NULL;							
@@ -523,7 +523,7 @@ void
 
 	SetElements(GetRows(), GetCols(), pElements, true);
 
-}	// CMatrixNxM<TYPE>::Transpose
+}	// MatrixNxM<TYPE>::Transpose
 
 #endif
 
@@ -533,7 +533,7 @@ void
 //////////////////////////////////////////////////////////////////////
 template<> INLINE
 bool 
-	CMatrixNxM<float>::Invert(bool bFlag)					
+	MatrixNxM<float>::Invert(bool bFlag)					
 	// invert the matrix, with full pivot or not???
 {															
 	ASSERT(GetRows() == GetCols());							
@@ -562,12 +562,12 @@ bool
 
 	return (stat == ippStsOk);								
 
-}	// CMatrixNxM<TYPE>::Invert
+}	// MatrixNxM<TYPE>::Invert
 
 //////////////////////////////////////////////////////////////////////
 template<> INLINE
 bool 
-	CMatrixNxM<double>::Invert(bool bFlag)					
+	MatrixNxM<double>::Invert(bool bFlag)					
 	// invert the matrix, with full pivot or not???
 {															
 	ASSERT(GetRows() == GetCols());							
@@ -596,14 +596,14 @@ bool
 
 	return (stat == ippStsOk);								
 
-}	// CMatrixNxM<TYPE>::Invert
+}	// MatrixNxM<TYPE>::Invert
 
 #endif
 
 //////////////////////////////////////////////////////////////////////
 template<class TYPE>
 void 
-	CMatrixNxM<TYPE>::SetElements(int nCols, int nRows, 
+	MatrixNxM<TYPE>::SetElements(int nCols, int nRows, 
 		TYPE *pElements, bool bFreeElements)
 	// sets the elements of the matrix
 {
@@ -645,14 +645,14 @@ void
 
 	m_bFreeElements = bFreeElements;
 
-}	// CMatrixNxM<TYPE>::SetElements
+}	// MatrixNxM<TYPE>::SetElements
 
 
 //////////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
 bool 
-	operator==(const CMatrixNxM<TYPE>& mLeft, 
-		const CMatrixNxM<TYPE>& mRight)
+	operator==(const MatrixNxM<TYPE>& mLeft, 
+		const MatrixNxM<TYPE>& mRight)
 	// exact matrix equality
 {
 	// element-by-element comparison
@@ -669,91 +669,91 @@ bool
 
 	return true;
 
-}	// operator==(const CMatrixNxM<TYPE>&, const CMatrixNxM<TYPE>&)
+}	// operator==(const MatrixNxM<TYPE>&, const MatrixNxM<TYPE>&)
 
 
 //////////////////////////////////////////////////////////////////////
 template<class TYPE> __forceinline
 bool 
-	operator!=(const CMatrixNxM<TYPE>& mLeft, 
-		const CMatrixNxM<TYPE>& mRight)
+	operator!=(const MatrixNxM<TYPE>& mLeft, 
+		const MatrixNxM<TYPE>& mRight)
 	// exact matrix inequality
 {
 	return !(mLeft == mRight);
 
-}	// operator!=(const CMatrixNxM<TYPE>&, const CMatrixNxM<TYPE>&)
+}	// operator!=(const MatrixNxM<TYPE>&, const MatrixNxM<TYPE>&)
 
 
 //////////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CMatrixNxM<TYPE> 
-	operator+(const CMatrixNxM<TYPE>& mLeft, 
-		const CMatrixNxM<TYPE>& mRight)
+MatrixNxM<TYPE> 
+	operator+(const MatrixNxM<TYPE>& mLeft, 
+		const MatrixNxM<TYPE>& mRight)
 	// matrix addition
 {
 	// create the product
-	CMatrixNxM<TYPE> mSum(mLeft);
+	MatrixNxM<TYPE> mSum(mLeft);
 	mSum += mRight;
 
 	// return the product
 	return mSum;
 
-}	// operator+(const CMatrixNxM<TYPE>&, const CMatrixNxM<TYPE>&)
+}	// operator+(const MatrixNxM<TYPE>&, const MatrixNxM<TYPE>&)
 
 
 //////////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CMatrixNxM<TYPE> 
-	operator-(const CMatrixNxM<TYPE>& mLeft, 
-		const CMatrixNxM<TYPE>& mRight)
+MatrixNxM<TYPE> 
+	operator-(const MatrixNxM<TYPE>& mLeft, 
+		const MatrixNxM<TYPE>& mRight)
 	// matrix subtraction
 {
 	// create the difference
-	CMatrixNxM<TYPE> mDiff(mLeft);
+	MatrixNxM<TYPE> mDiff(mLeft);
 	mDiff -= mRight;
 
 	// return the difference
 	return mDiff;
 
-}	// operator-(const CMatrixNxM<TYPE>&, const CMatrixNxM<TYPE>&)
+}	// operator-(const MatrixNxM<TYPE>&, const MatrixNxM<TYPE>&)
 
 
 //////////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CMatrixNxM<TYPE> 
-	operator*(const CMatrixNxM<TYPE>& mat, double scale)
+MatrixNxM<TYPE> 
+	operator*(const MatrixNxM<TYPE>& mat, double scale)
 	// matrix scalar multiplication
 {
 	// stored the product
-	CMatrixNxM<TYPE> mProduct(mat);
+	MatrixNxM<TYPE> mProduct(mat);
 	mProduct *= scale;
 
 	// return product
 	return mProduct;
 
-}	// operator*(const CMatrixNxM<TYPE>&, double scale)
+}	// operator*(const MatrixNxM<TYPE>&, double scale)
 
 
 //////////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CMatrixNxM<TYPE> 
-	operator*(double scale, const CMatrixNxM<TYPE>& mat)
+MatrixNxM<TYPE> 
+	operator*(double scale, const MatrixNxM<TYPE>& mat)
 	// matrix scalar multiplication, contrariwise
 {
 	// stored the product
-	CMatrixNxM<TYPE> mProduct(mat);
+	MatrixNxM<TYPE> mProduct(mat);
 	mProduct *= scale;
 
 	// return product
 	return mProduct;
 
-}	// operator*(double scale, const CMatrixNxM<TYPE>&)
+}	// operator*(double scale, const MatrixNxM<TYPE>&)
 
 
 //////////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
 CVectorN<TYPE> 
-	operator*(const CMatrixNxM<TYPE>& mat, const CVectorN<TYPE>& v)
+	operator*(const MatrixNxM<TYPE>& mat, const CVectorN<TYPE>& v)
 	// matrix-vector multiplication
 {
 	// stored the product
@@ -765,7 +765,7 @@ CVectorN<TYPE>
 	// return the product
 	return vProduct;
 
-}	// operator*(const CMatrixNxM<TYPE>&, const CVectorN<TYPE>&)
+}	// operator*(const MatrixNxM<TYPE>&, const CVectorN<TYPE>&)
 
 
 #ifdef NEVER // USE_IPP
@@ -773,7 +773,7 @@ CVectorN<TYPE>
 //////////////////////////////////////////////////////////////////////
 template<> INLINE
 CVectorN<float> 
-	operator*(const CMatrixNxM<float>& mat,
+	operator*(const MatrixNxM<float>& mat,
 			const CVectorN<float>& v)
 	// matrix-vector multiplication for float override
 {											
@@ -789,12 +789,12 @@ CVectorN<float>
 	// return the product
 	return vProduct;
 
-}	// operator*(const CMatrixNxM<TYPE>&, const CVectorN<TYPE>&)
+}	// operator*(const MatrixNxM<TYPE>&, const CVectorN<TYPE>&)
 
 //////////////////////////////////////////////////////////////////////
 template<> INLINE
 CVectorN<double> 
-	operator*(const CMatrixNxM<double>& mat,
+	operator*(const MatrixNxM<double>& mat,
 			const CVectorN<double>& v)
 	// matrix-vector multiplication for float override
 {											
@@ -810,30 +810,30 @@ CVectorN<double>
 	// return the product
 	return vProduct;
 
-}	// operator*(const CMatrixNxM<TYPE>&, const CVectorN<TYPE>&)
+}	// operator*(const MatrixNxM<TYPE>&, const CVectorN<TYPE>&)
 
 #endif
 
 
 //////////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CMatrixNxM<TYPE> operator*(const CMatrixNxM<TYPE>& mLeft, 
-									const CMatrixNxM<TYPE>& mRight)
+MatrixNxM<TYPE> operator*(const MatrixNxM<TYPE>& mLeft, 
+									const MatrixNxM<TYPE>& mRight)
 	// matrix multiplication
 {
 	// create the product
-	CMatrixNxM<TYPE> mProduct(mRight.GetCols(), mLeft.GetRows());
+	MatrixNxM<TYPE> mProduct(mRight.GetCols(), mLeft.GetRows());
 	MultMatrixMatrix(mProduct, mLeft, mRight);
 
 	// return the product
 	return mProduct;
 
-}	// operator*(const CMatrixNxM<TYPE>&, const CMatrixNxM<TYPE>&)
+}	// operator*(const MatrixNxM<TYPE>&, const MatrixNxM<TYPE>&)
 
 
 //////////////////////////////////////////////////////////////////////
 template<class TYPE>
-TYPE Determinant(const CMatrixNxM<TYPE>& mMat) 
+TYPE Determinant(const MatrixNxM<TYPE>& mMat) 
 	// computes the determinant of the matrix, for square matrices
 	// TODO: move this to MatrixOps
 	// TODO: implement IPP determinant
@@ -845,7 +845,7 @@ TYPE Determinant(const CMatrixNxM<TYPE>& mMat)
 		TYPE det = 0.0;
 		for (int nAtCol = 0; nAtCol < mMat.GetCols(); nAtCol++) 
 		{
-			CMatrixNxM<TYPE> mMinor(mMat.GetCols()-1, mMat.GetRows()-1);
+			MatrixNxM<TYPE> mMinor(mMat.GetCols()-1, mMat.GetRows()-1);
 			for (int nAtRow = 1; nAtRow < mMat.GetRows(); nAtRow++) 
 			{
 				int nAtMinorCol = 0;
@@ -871,7 +871,7 @@ TYPE Determinant(const CMatrixNxM<TYPE>& mMat)
 	
 	return mMat[0][0];
 
-}	// CMatrixNxM<TYPE>::Determinant
+}	// MatrixNxM<TYPE>::Determinant
 
 
 // operator overloads for serialization
@@ -880,7 +880,7 @@ TYPE Determinant(const CMatrixNxM<TYPE>& mMat)
 //////////////////////////////////////////////////////////////////////
 template<class TYPE>
 CArchive& 
-	operator<<(CArchive &ar, CMatrixNxM<TYPE> m)
+	operator<<(CArchive &ar, MatrixNxM<TYPE> m)
 	// matrix serialization in
 {
 	// serialize the dimension
@@ -893,12 +893,12 @@ CArchive&
 	// return the archive object
 	return ar;
 
-}	// operator<<(CArchive &ar, CMatrixNxM<TYPE> m)
+}	// operator<<(CArchive &ar, MatrixNxM<TYPE> m)
 
 //////////////////////////////////////////////////////////////////////
 template<class TYPE>
 CArchive& 
-	operator>>(CArchive &ar, CMatrixNxM<TYPE>& m)
+	operator>>(CArchive &ar, MatrixNxM<TYPE>& m)
 	// matrix serialization out
 {
 	// serialize the dimension
@@ -912,7 +912,7 @@ CArchive&
 	// return the archive object
 	return ar;
 
-}	// operator>>(CArchive &ar, CMatrixNxM<TYPE>& m)
+}	// operator>>(CArchive &ar, MatrixNxM<TYPE>& m)
 
 #endif	// __AFX_H__
 
@@ -922,7 +922,7 @@ CArchive&
 ////////////////////////////////////////////////////////////////////////
 //template<typename TYPE>
 //void 
-//	LogExprExt(const CMatrixNxM<TYPE>& mMat, 
+//	LogExprExt(const MatrixNxM<TYPE>& mMat, 
 //			const char *pszName, const char *pszModule)
 //	// helper function for XML logging of matrices
 //{
@@ -959,3 +959,7 @@ CArchive&
 //}	// LogExprExt
 //
 //#endif	// USE_XMLLOGGING
+
+// Backward compatibility
+template<class TYPE = REAL>
+using CMatrixNxM = MatrixNxM<TYPE>;

--- a/src/OptimizeN/include/ObjectiveFunction.h
+++ b/src/OptimizeN/include/ObjectiveFunction.h
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////
-// ObjectiveFunction.h: interface for the CObjectiveFunction
+// ObjectiveFunction.h: interface for the ObjectiveFunction
 //		template base class
 //
 // Copyright (C) 1996-2001
@@ -16,45 +16,48 @@
 #include <MatrixNxM.h>
 
 //////////////////////////////////////////////////////////////////////
-// class CObjectiveFunction
+// class ObjectiveFunction
 // 
 // base class template for all objective functions.  allows the 
 //		objective function to define a gradient, but a flag is provided
 //		in the case that no gradient is available
 //////////////////////////////////////////////////////////////////////
-class CObjectiveFunction : public CObject
+class ObjectiveFunction
 {
 public:
 	// constructs an objective function; gets flag to indicate
 	//		whether gradient information is available
-	CObjectiveFunction(BOOL bHasGradientInfo);
+	ObjectiveFunction(BOOL bHasGradientInfo);
+
+	// virtual destructor
+	virtual ~ObjectiveFunction() = default;
 
 	// evaluates the objective function
-	virtual REAL operator()(const CVectorN<>& vInput, 
-		CVectorN<> *pGrad = NULL) const = 0;
+	virtual REAL operator()(const VectorN<>& vInput, 
+		VectorN<> *pGrad = NULL) const = 0;
 
 	// whether gradient information is available
 	BOOL HasGradientInfo() const;
 
 	// transform function from linear to other parameter space
-	virtual void Transform(CVectorN<> *pvInOut) const;
-	virtual void dTransform(CVectorN<> *pvInOut) const;
-	virtual void InvTransform(CVectorN<> *pvInOut) const;
+	virtual void Transform(VectorN<> *pvInOut) const;
+	virtual void dTransform(VectorN<> *pvInOut) const;
+	virtual void InvTransform(VectorN<> *pvInOut) const;
 
 	// function to evaluate gradiant at a point (uses difference method)
-	void Gradient(const CVectorN<>& vIn, REAL epsilon, 
-				CVectorN<>& vGrad_out) const;
+	void Gradient(const VectorN<>& vIn, REAL epsilon, 
+				VectorN<>& vGrad_out) const;
 
 	// function to evaluate hessian at a point (uses difference method)
-	void Hessian(const CVectorN<>& vIn, REAL epsilon, 
-				CMatrixNxM<>& mHess_out) const;
+	void Hessian(const VectorN<>& vIn, REAL epsilon, 
+				MatrixNxM<>& mHess_out) const;
 
 	// sets the OF to use adaptive variance
-	void SetAdaptiveVariance(CVectorN<> *pAV, REAL varMin, REAL varMax);
+	void SetAdaptiveVariance(VectorN<> *pAV, REAL varMin, REAL varMax);
 
 protected:
 	// pointer to adaptive variance vector, if enabled
-	CVectorN<> *m_pAV;
+	VectorN<> *m_pAV;
 
 	// min and max for AV
 	REAL m_varMin;
@@ -64,6 +67,9 @@ private:
 	// flag to indicate that gradient information is available
 	BOOL m_bHasGradientInfo;
 
-};	// class CObjectiveFunction
+};	// class ObjectiveFunction
+
+// Backward compatibility
+using CObjectiveFunction = ObjectiveFunction;
 
 #endif

--- a/src/OptimizeN/include/Optimizer.h
+++ b/src/OptimizeN/include/Optimizer.h
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////
-// Optimizer.h: interface for the COptimizer template
+// Optimizer.h: interface for the Optimizer template
 //
 // Copyright (C) 1996-2001
 // $Id: Optimizer.h,v 1.3 2006/04/01 16:47:16 HP_Administrator Exp $
@@ -16,24 +16,24 @@
 // include for the objective function
 #include "ObjectiveFunction.h"
 
-class COptimizer;
+class Optimizer;
 
 // callback function
-typedef BOOL OptimizerCallback(COptimizer *pOpt, void *pParam);
+typedef BOOL OptimizerCallback(Optimizer *pOpt, void *pParam);
 
 //////////////////////////////////////////////////////////////////////
-// class COptimizer
+// class Optimizer
 // 
 // base template class for all optimizers
 //////////////////////////////////////////////////////////////////////
-class COptimizer
+class Optimizer
 {
 public:
-	// construct a new COptimizer object
-	COptimizer(CObjectiveFunction *pFunc);
+	// construct a new Optimizer object
+	Optimizer(ObjectiveFunction *pFunc);
 
 	// destroy the optimizer
-	virtual ~COptimizer();
+	virtual ~Optimizer();
 
 	// sets the callback function
 	void SetCallback(OptimizerCallback *pCallback, void *pParam = NULL);
@@ -54,14 +54,14 @@ public:
 	REAL GetFinalValue() const;
 
 	// holds the final value of the parameters for the minimum f
-	const CVectorN<>& GetFinalParameter() const;
+	const VectorN<>& GetFinalParameter() const;
 
 	// function to actually perform the optimization
-	virtual const CVectorN<>& Optimize(const CVectorN<>& vInit) = 0;
+	virtual const VectorN<>& Optimize(const VectorN<>& vInit) = 0;
 
 protected:
 	// the objective function over which optimization is to occur
-	CObjectiveFunction *m_pFunc;
+	ObjectiveFunction *m_pFunc;
 
 	// stores the callback info
 	OptimizerCallback *m_pCallbackFunc;
@@ -78,13 +78,16 @@ protected:
 
 	// holds the final input parameter to the objective function (same as
 	//		returned by Optimize)
-	CVectorN<> m_vFinalParam;
+	VectorN<> m_vFinalParam;
 
 private:
 	// flag to indicate whether gradient information should be used
 	BOOL m_bUseGradientInfo;
 
-};	// class COptimizer
+};	// class Optimizer
 
+
+// Backward compatibility
+using COptimizer = Optimizer;
 
 #endif // !defined(OPTIMIZER_H)

--- a/src/OptimizeN/include/PowellOptimizer.h
+++ b/src/OptimizeN/include/PowellOptimizer.h
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////
-// PowellOptimizer.h: interface for the CPowellOptimizer 
+// PowellOptimizer.h: interface for the PowellOptimizer 
 //
 // Copyright (C) 1996-2001
 // $Id: PowellOptimizer.h,v 1.2 2004/03/28 22:35:09 default Exp $
@@ -21,20 +21,20 @@
 #include "LineFunction.h"
 
 //////////////////////////////////////////////////////////////////////
-// class CPowellOptimizer
+// class PowellOptimizer
 // 
 // optimizer that implements the Powell algorithm explained in
 //		Numerical Recipes
 //////////////////////////////////////////////////////////////////////
-class CPowellOptimizer : public COptimizer
+class PowellOptimizer : public Optimizer
 {
 public:
 	// construct a new Powell optimizer
-	CPowellOptimizer(CObjectiveFunction *pFunc);
-	virtual ~CPowellOptimizer();
+	PowellOptimizer(ObjectiveFunction *pFunc);
+	virtual ~PowellOptimizer();
 
 	// performs the optimization
-	virtual const CVectorN<>& Optimize(const CVectorN<>& vInit);
+	virtual const VectorN<>& Optimize(const VectorN<>& vInit);
 
 protected:
 	// helper functions for optimization
@@ -43,19 +43,22 @@ protected:
 
 private:
 	// line function that projects the objective function along a given line
-	CLineFunction m_lineFunction;
+	LineFunction m_lineFunction;
 
 	// brent optimizer along the line function
-	CBrentOptimizer m_optimizeBrent;
+	BrentOptimizer m_optimizeBrent;
 
 	// the current direction set for the optimization
-	CMatrixNxM<> m_mDirections;
+	MatrixNxM<> m_mDirections;
 
 	// "locals" for the optimization, declared members to avoid initializing
-	CVectorN<> m_vScaledDir;
-	CVectorN<> m_vPt;
-	CVectorN<> m_vPtt;
-	CVectorN<> m_vXit;
+	VectorN<> m_vScaledDir;
+	VectorN<> m_vPt;
+	VectorN<> m_vPtt;
+	VectorN<> m_vXit;
 };
+
+// Backward compatibility
+using CPowellOptimizer = PowellOptimizer;
 
 #endif

--- a/src/OptimizeN/include/Pseudoinverse.h
+++ b/src/OptimizeN/include/Pseudoinverse.h
@@ -16,14 +16,14 @@ const REAL PSEUDO_EPS = 1e-8f;
 //////////////////////////////////////////////////////////////////
 template<class TYPE>
 bool 
-	Pseudoinvert(const CMatrixNxM<TYPE>& mFrom, CMatrixNxM<TYPE>& mTo)
+	Pseudoinvert(const MatrixNxM<TYPE>& mFrom, MatrixNxM<TYPE>& mTo)
 	// in-place Moore-Penrose pseudoinversion
 {
 	mTo.Reshape(mFrom.GetCols(), mFrom.GetRows());
 	mTo = mFrom;
 
-	CVectorN<TYPE> w(mTo.GetCols());
-	CMatrixNxM<TYPE> v(mTo.GetCols(), mTo.GetCols());
+	VectorN<TYPE> w(mTo.GetCols());
+	MatrixNxM<TYPE> v(mTo.GetCols(), mTo.GetCols());
 	if (!SVD(mTo, w, v))
 	{
 		return FALSE;
@@ -32,7 +32,7 @@ bool
 	// using the formula (A+)^T = U * {1/w} * V^T
 
 	// form the S matrix (S^T * S)^-1 * S^T
-	CMatrixNxM<TYPE> s(mTo.GetCols(), mTo.GetCols());
+	MatrixNxM<TYPE> s(mTo.GetCols(), mTo.GetCols());
 	for (int nAt = 0; nAt < mTo.GetCols(); nAt++)
 	{
 		s[nAt][nAt] = (w[nAt] > PSEUDO_EPS) ? 1.0 / w[nAt] : 0.0;
@@ -50,7 +50,7 @@ bool
 
 	return TRUE;
 
-}	// CMatrixNxM<TYPE>::Pseudoinvert
+}	// MatrixNxM<TYPE>::Pseudoinvert
 
 
 // maximum iterations for SVD
@@ -83,15 +83,15 @@ TYPE
 //////////////////////////////////////////////////////////////////////
 template<class TYPE>
 bool 
-	SVD(CMatrixNxM<>& mFrom, CVectorN<TYPE>& w, CMatrixNxM<TYPE>& v)
+	SVD(MatrixNxM<>& mFrom, VectorN<TYPE>& w, MatrixNxM<TYPE>& v)
 	// computes the singular-valued decomposition of this matrix,
 	//		leaving U in the matrix and returning the singular values
 	//		in w and v (not v^T)
 {
-	BEGIN_LOG_SECTION(CMatrixNxM::SVD);
+	BEGIN_LOG_SECTION(MatrixNxM::SVD);
 
 	// stored reduction vector
-	CVectorN<TYPE> rv1(mFrom.GetCols());
+	VectorN<TYPE> rv1(mFrom.GetCols());
 
 	// perform the householder reduction
 	TYPE anorm = Householder(mFrom, w, rv1);
@@ -252,19 +252,19 @@ bool
 		}
 	}
 
-	END_LOG_SECTION();	// CMatrixNxM::SVD
+	END_LOG_SECTION();	// MatrixNxM::SVD
 
 	return TRUE;
 
-}	// CMatrixNxM<TYPE>::SVD
+}	// MatrixNxM<TYPE>::SVD
 
 
 //////////////////////////////////////////////////////////////////////
 template<class TYPE>
 TYPE 
-	Householder(CMatrixNxM<TYPE>& m, 
-			CVectorN<TYPE>& w, 
-			CVectorN<TYPE>& rv1)
+	Householder(MatrixNxM<TYPE>& m, 
+			VectorN<TYPE>& w, 
+			VectorN<TYPE>& rv1)
 	// helper function for SVD to perform Householder decomposition
 {
 	TYPE anorm = 0.0;
@@ -370,15 +370,15 @@ TYPE
 
 	return anorm;
 
-}	// CMatrixNxM<TYPE>::Householder
+}	// MatrixNxM<TYPE>::Householder
 
 
 //////////////////////////////////////////////////////////////////////
 template<class TYPE>
 void 
-	AccumulateRH(const CMatrixNxM<TYPE>& m, 
-			CMatrixNxM<TYPE>& v, 
-			const CVectorN<TYPE>& rv1)
+	AccumulateRH(const MatrixNxM<TYPE>& m, 
+			MatrixNxM<TYPE>& v, 
+			const VectorN<TYPE>& rv1)
 	// helper function for SVD to accumulate right-hand products
 {
 	// Accumulation of right-hand transformations
@@ -415,13 +415,13 @@ void
 		}
 	}
 
-}	// CMatrixNxM<TYPE>::AccumulateRH
+}	// MatrixNxM<TYPE>::AccumulateRH
 
 
 //////////////////////////////////////////////////////////////////////
 template<class TYPE>
 void 
-	AccumulateLH(CMatrixNxM<TYPE>& m, CVectorN<TYPE>& w)
+	AccumulateLH(MatrixNxM<TYPE>& m, VectorN<TYPE>& w)
 	// helper function for SVD to accumulate left-hand products
 {
 	for (int nI = __min(m.GetRows()-1, m.GetCols()-1); nI >= 0; nI--)
@@ -466,4 +466,4 @@ void
 		++m[nI][nI];
 	}
 
-}	// CMatrixNxM<TYPE>::AccumulateLH
+}	// MatrixNxM<TYPE>::AccumulateLH

--- a/src/OptimizeN/include/VectorN.h
+++ b/src/OptimizeN/include/VectorN.h
@@ -1,5 +1,5 @@
 //////////////////////////////////////////////////////////////////////
-// VectorN.h: declaration and definition of the CVectorN dynamic 
+// VectorN.h: declaration and definition of the VectorN dynamic 
 //		vector template class.
 //
 // Copyright (C) 1999-2006 Derek G Lane
@@ -18,13 +18,13 @@
 #include <VectorOps.h>
 
 //////////////////////////////////////////////////////////////////////
-// class CVectorN<TYPE>
+// class VectorN<TYPE>
 //
 // represents a dynamically sizable mathematical vector with element
 //		type given
 //////////////////////////////////////////////////////////////////////
 template<class TYPE = REAL>
-class CVectorN
+class VectorN
 {
 	// dimension of vector
 	int m_nDim;
@@ -37,13 +37,13 @@ class CVectorN
 
 public:
 	// constructors / destructor
-	CVectorN();
-	explicit CVectorN(int nDim);
-	CVectorN(const CVectorN& vFrom);
-	~CVectorN();
+	VectorN();
+	explicit VectorN(int nDim);
+	VectorN(const VectorN& vFrom);
+	~VectorN();
 
 	// assignment operator
-	CVectorN& operator=(const CVectorN& vFrom);
+	VectorN& operator=(const VectorN& vFrom);
 
 	// template helper for element type
 	typedef TYPE ELEM_TYPE;
@@ -69,12 +69,12 @@ public:
 	void Normalize();
 
 	// approximate equality using the epsilon
-	bool IsApproxEqual(const CVectorN& v, TYPE epsilon = DEFAULT_EPSILON) const;
+	bool IsApproxEqual(const VectorN& v, TYPE epsilon = DEFAULT_EPSILON) const;
 
 	// in-place vector arithmetic
-	CVectorN& operator+=(const CVectorN& vRight);
-	CVectorN& operator-=(const CVectorN& vRight);
-	CVectorN& operator*=(const TYPE& scalar);
+	VectorN& operator+=(const VectorN& vRight);
+	VectorN& operator-=(const VectorN& vRight);
+	VectorN& operator*=(const TYPE& scalar);
 
 	//////////////////////////////////////////////////////////////////////
 	// low-level element management
@@ -84,26 +84,26 @@ public:
 
 	// copy elements from v, starting at start, for length elements, 
 	//		and copy them to the destination position
-	int CopyElements(const CVectorN<TYPE>& v, int nStart, int nLength, 
+	int CopyElements(const VectorN<TYPE>& v, int nStart, int nLength, 
 		int nDest = 0);
 
-};	// class CVectorN<TYPE>
+};	// class VectorN<TYPE>
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CVectorN<TYPE>::CVectorN() 
+VectorN<TYPE>::VectorN() 
 	: m_nDim(0),
 		m_pElements(NULL),
 		m_bFreeElements(TRUE)
 	// default constructor
 {
-}	// CVectorN<TYPE>::CVectorN<TYPE>
+}	// VectorN<TYPE>::VectorN<TYPE>
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CVectorN<TYPE>::CVectorN(int nDim) 
+VectorN<TYPE>::VectorN(int nDim) 
 	: m_nDim(0),
 		m_pElements(NULL),
 		m_bFreeElements(TRUE)
@@ -112,12 +112,12 @@ CVectorN<TYPE>::CVectorN(int nDim)
 	// set the dimensionality of the vector
 	SetDim(nDim);
 
-}	// CVectorN<TYPE>::CVectorN<TYPE>(int nDim) 
+}	// VectorN<TYPE>::VectorN<TYPE>(int nDim) 
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CVectorN<TYPE>::CVectorN(const CVectorN<TYPE>& vFrom)
+VectorN<TYPE>::VectorN(const VectorN<TYPE>& vFrom)
 	: m_nDim(0),
 		m_pElements(NULL),
 		m_bFreeElements(TRUE)
@@ -129,12 +129,12 @@ CVectorN<TYPE>::CVectorN(const CVectorN<TYPE>& vFrom)
 	// copy the elements
 	(*this) = vFrom;
 
-}	// CVectorN<TYPE>::CVectorN<TYPE>(const CVectorN<TYPE>& vFrom)
+}	// VectorN<TYPE>::VectorN<TYPE>(const VectorN<TYPE>& vFrom)
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CVectorN<TYPE>::~CVectorN()
+VectorN<TYPE>::~VectorN()
 	// destructor 
 {
 	if (m_bFreeElements 
@@ -144,15 +144,15 @@ CVectorN<TYPE>::~CVectorN()
 		FreeValues(m_pElements);
 	}
 
-}	// CVectorN<TYPE>::~CVectorN<TYPE>
+}	// VectorN<TYPE>::~VectorN<TYPE>
 
 
 //////////////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CVectorN<TYPE>& 
-	CVectorN<TYPE>::operator=(const CVectorN<TYPE>& vFrom)
+VectorN<TYPE>& 
+	VectorN<TYPE>::operator=(const VectorN<TYPE>& vFrom)
 	// assignment operator
 {
 	// check the dimensionality of the vector
@@ -173,13 +173,13 @@ CVectorN<TYPE>&
 	// return a reference to this
 	return (*this);
 
-}	// CVectorN<TYPE>::operator=
+}	// VectorN<TYPE>::operator=
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
 TYPE& 
-	CVectorN<TYPE>::operator[](int nAtRow)
+	VectorN<TYPE>::operator[](int nAtRow)
 	// returns a reference to the specified element.
 {
 	// check dimensions
@@ -187,13 +187,13 @@ TYPE&
 
 	return m_pElements[nAtRow];
 
-}	// CVectorN<TYPE>::operator[]
+}	// VectorN<TYPE>::operator[]
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
 const TYPE& 
-	CVectorN<TYPE>::operator[](int nAtRow) const
+	VectorN<TYPE>::operator[](int nAtRow) const
 	// returns a const reference to the specified element.
 {
 	// check dimensions
@@ -201,47 +201,47 @@ const TYPE&
 
 	return m_pElements[nAtRow];
 
-}	// CVectorN<TYPE>::operator[] const
+}	// VectorN<TYPE>::operator[] const
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CVectorN<TYPE>::operator TYPE *()
+VectorN<TYPE>::operator TYPE *()
 	// TYPE * conversion -- returns a pointer to the first element
 	//		WARNING: this allows for no-bounds-checking access
 {
 	return &m_pElements[0];
 
-}	// CVectorN<TYPE>::operator TYPE *
+}	// VectorN<TYPE>::operator TYPE *
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CVectorN<TYPE>::operator const TYPE *() const
+VectorN<TYPE>::operator const TYPE *() const
 	// const TYPE * conversion -- returns a pointer to the first 
 	//		element.
 	//		WARNING: this allows for no-bounds-checking access
 {
 	return &m_pElements[0];
 
-}	// CVectorN<TYPE>::operator const TYPE *
+}	// VectorN<TYPE>::operator const TYPE *
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
 int 
-	CVectorN<TYPE>::GetDim() const
+	VectorN<TYPE>::GetDim() const
 	// returns the dimensionality of the vector
 {
 	return m_nDim;
 
-}	// CVectorN<TYPE>::GetDim
+}	// VectorN<TYPE>::GetDim
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE>
 void 
-	CVectorN<TYPE>::SetDim(int nDim)
+	VectorN<TYPE>::SetDim(int nDim)
 	// sets the dimensionality of this vector
 {
 	// do nothing if the dim is already correct
@@ -281,25 +281,25 @@ void
 		}
 	}
 
-}	// CVectorN<TYPE>::SetDim
+}	// VectorN<TYPE>::SetDim
 
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
 TYPE 
-	CVectorN<TYPE>::GetLength() const
+	VectorN<TYPE>::GetLength() const
 	// returns the euclidean length of the vector
 {
 	return VectorLength(&(*this)[0], GetDim());
 
-}	// CVectorN<TYPE>::GetLength
+}	// VectorN<TYPE>::GetLength
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
 void 
-	CVectorN<TYPE>::Normalize()
+	VectorN<TYPE>::Normalize()
 	// scales the vector so its length is 1.0
 {
 	TYPE len = GetLength();
@@ -308,69 +308,69 @@ void
 		MultValues(&(*this)[0], (TYPE) 1.0 / len, GetDim());
 	}
 
-}	// CVectorN<TYPE>::Normalize
+}	// VectorN<TYPE>::Normalize
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
 bool 
-	CVectorN<TYPE>::IsApproxEqual(const CVectorN<TYPE>& v, 
+	VectorN<TYPE>::IsApproxEqual(const VectorN<TYPE>& v, 
 			TYPE epsilon) const
 	// tests for approximate equality using the EPS defined at 
 	//		the top of this file
 {
 	// form the difference vector
-	CVectorN<TYPE> vDiff(*this);
+	VectorN<TYPE> vDiff(*this);
 	vDiff -= v;
 
 	return (vDiff.GetLength() < epsilon);
 
-}	// CVectorN<TYPE>::IsApproxEqual
+}	// VectorN<TYPE>::IsApproxEqual
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CVectorN<TYPE>& 
-	CVectorN<TYPE>::operator+=(const CVectorN<TYPE>& vRight)
+VectorN<TYPE>& 
+	VectorN<TYPE>::operator+=(const VectorN<TYPE>& vRight)
 	// in-place vector addition; returns a reference to this	
 {
 	SumValues(&(*this)[0], &vRight[0], GetDim());
 
 	return (*this);
 
-}	// CVectorN<TYPE>::operator+=
+}	// VectorN<TYPE>::operator+=
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CVectorN<TYPE>& 
-	CVectorN<TYPE>::operator-=(const CVectorN<TYPE>& vRight)
+VectorN<TYPE>& 
+	VectorN<TYPE>::operator-=(const VectorN<TYPE>& vRight)
 	// in-place vector subtraction; returns a reference to this
 {
 	DiffValues(&(*this)[0], &vRight[0], GetDim());
 
 	return (*this);
 
-}	// CVectorN<TYPE>::operator-=
+}	// VectorN<TYPE>::operator-=
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CVectorN<TYPE>& 
-	CVectorN<TYPE>::operator*=(const TYPE& scalar)
+VectorN<TYPE>& 
+	VectorN<TYPE>::operator*=(const TYPE& scalar)
 	// in-place scalar multiplication; returns a reference to this
 {
 	MultValues(&(*this)[0], scalar, GetDim());
 
 	return (*this);
 
-}	// CVectorN<TYPE>::operator*=
+}	// VectorN<TYPE>::operator*=
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE>
 void 
-	CVectorN<TYPE>::SetElements(int nDim, TYPE *pElements,
+	VectorN<TYPE>::SetElements(int nDim, TYPE *pElements,
 			bool bFreeElements)
 	// management for external elements
 {
@@ -385,13 +385,13 @@ void
 	m_pElements = pElements;
 	m_bFreeElements = bFreeElements;
 
-}	// CVectorN<TYPE>::SetElements
+}	// VectorN<TYPE>::SetElements
 
 
 //////////////////////////////////////////////////////////////////
 template<class TYPE>
 int 
-	CVectorN<TYPE>::CopyElements(const CVectorN<TYPE>& v, 
+	VectorN<TYPE>::CopyElements(const VectorN<TYPE>& v, 
 			int nStart, int nLength, int nDest)
 	// copy elements from v, starting at start, for length elements, 
 	//		and copy them to the destination position
@@ -408,14 +408,14 @@ int
 
 	return nLength;
 
-}	// CVectorN<TYPE>::CopyElements
+}	// VectorN<TYPE>::CopyElements
 
 
 //////////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
 bool 
-	operator==(const CVectorN<TYPE>& vLeft, 
-			const CVectorN<TYPE>& vRight)
+	operator==(const VectorN<TYPE>& vLeft, 
+			const VectorN<TYPE>& vRight)
 	// friend function to provide exact equality comparison for vectors.
 	// use IsApproxEqual for approximate equality.
 {
@@ -430,75 +430,75 @@ bool
 
 	return true;
 
-}	// operator==(const CVectorN, const CVectorN)
+}	// operator==(const VectorN, const VectorN)
 
 
 //////////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
 bool 
-	operator!=(const CVectorN<TYPE>& vLeft, 
-			const CVectorN<TYPE>& vRight)
+	operator!=(const VectorN<TYPE>& vLeft, 
+			const VectorN<TYPE>& vRight)
 	// friend function to provide exact inequality comparison for vectors.
 	// use !IsApproxEqual for approximate inequality.
 {
 	return !(vLeft == vRight);
 
-}	// operator!=(const CVectorN, const CVectorN)
+}	// operator!=(const VectorN, const VectorN)
 
 
 //////////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CVectorN<TYPE> 
-	operator+(const CVectorN<TYPE>& vLeft, 
-			const CVectorN<TYPE>& vRight)
+VectorN<TYPE> 
+	operator+(const VectorN<TYPE>& vLeft, 
+			const VectorN<TYPE>& vRight)
 	// friend function to add two vectors, returning the sum as a new 
 	//		vector
 {
-	CVectorN<TYPE> vSum(vLeft);
+	VectorN<TYPE> vSum(vLeft);
 	vSum += vRight;
 
 	return vSum;
 
-}	// operator+(const CVectorN, const CVectorN)
+}	// operator+(const VectorN, const VectorN)
 
 
 //////////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CVectorN<TYPE> 
-	operator-(const CVectorN<TYPE>& vLeft, 
-			const CVectorN<TYPE>& vRight)
+VectorN<TYPE> 
+	operator-(const VectorN<TYPE>& vLeft, 
+			const VectorN<TYPE>& vRight)
 	// friend function to subtract one vector from another, returning 
 	//		the difference as a new vector
 {
-	CVectorN<TYPE> vDiff(vLeft);
+	VectorN<TYPE> vDiff(vLeft);
 	vDiff -= vRight;
 
 	return vDiff;
 
-}	// operator-(const CVectorN, const CVectorN)
+}	// operator-(const VectorN, const VectorN)
 
 
 //////////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
 TYPE 
-	operator*(const CVectorN<TYPE>& vLeft, 
-			const CVectorN<TYPE>& vRight)
+	operator*(const VectorN<TYPE>& vLeft, 
+			const VectorN<TYPE>& vRight)
 	// friend function for vector inner product
 {
 	return DotProduct(&vLeft[0], &vRight[0], vLeft.GetDim());
 
-}	// operator*(const CVectorN, const CVectorN)
+}	// operator*(const VectorN, const VectorN)
 
 
 //////////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CVectorN<TYPE> 
+VectorN<TYPE> 
 	operator*(const TYPE& scalar, 
-			const CVectorN<TYPE>& vRight)
+			const VectorN<TYPE>& vRight)
 	// friend function for scalar multiplication of a vector
 {
 	// copy vector to intermediate product value
-	CVectorN<TYPE> vProd(vRight);
+	VectorN<TYPE> vProd(vRight);
 
 	// in-place scalar multiplication
 	vProd *= scalar;
@@ -506,18 +506,18 @@ CVectorN<TYPE>
 	// return the result
 	return vProd;
 
-}	// operator*(TYPE scalar, const CVectorN)
+}	// operator*(TYPE scalar, const VectorN)
 
 
 //////////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
-CVectorN<TYPE> 
-	operator*(const CVectorN<TYPE>& vLeft, 
+VectorN<TYPE> 
+	operator*(const VectorN<TYPE>& vLeft, 
 			const TYPE& scalar)
 	// friend function for scalar multiplication of a vector
 {
 	// copy vector to intermediate product value
-	CVectorN<TYPE> vProd(vLeft);
+	VectorN<TYPE> vProd(vLeft);
 
 	// in-place scalar multiplication
 	vProd *= scalar;
@@ -525,16 +525,16 @@ CVectorN<TYPE>
 	// return the result
 	return vProd;
 
-}	// operator*(const CVectorN, TYPE scalar)
+}	// operator*(const VectorN, TYPE scalar)
 
 
 ///////////////////////////////////////////////////////////////////////////////
 template<class TYPE> INLINE
 void 
-	CalcBinomialCoeff(CVectorN<TYPE>& vCoeff)
+	CalcBinomialCoeff(VectorN<TYPE>& vCoeff)
 	// calculates the binomial coefficients, returns in the vector
 {
-	CVectorN<TYPE> vAltCoeff;
+	VectorN<TYPE> vAltCoeff;
 	vAltCoeff.SetDim(vCoeff.GetDim());
 
 	for (int nAt = 0; nAt < vCoeff.GetDim()-1; nAt++)
@@ -555,7 +555,7 @@ void
 //////////////////////////////////////////////////////////////////////
 template<class TYPE>
 void 
-	TraceVector(const CVectorN<TYPE>& vTrace)
+	TraceVector(const VectorN<TYPE>& vTrace)
 	// helper function to output a vector for debugging
 {
 #ifdef _DEBUG
@@ -592,7 +592,7 @@ void
 //////////////////////////////////////////////////////////////////////
 template<class TYPE>
 CArchive& 
-	operator<<(CArchive &ar, CVectorN<TYPE> v)
+	operator<<(CArchive &ar, VectorN<TYPE> v)
 	// CArchive serialization of a vector
 {
 	// store the dimension first
@@ -606,12 +606,12 @@ CArchive&
 
 	return ar;
 
-}	// operator<<(CArchive &ar, CVectorN<TYPE> v)
+}	// operator<<(CArchive &ar, VectorN<TYPE> v)
 
 //////////////////////////////////////////////////////////////////////
 template<class TYPE>
 CArchive& 
-	operator>>(CArchive &ar, CVectorN<TYPE>& v)
+	operator>>(CArchive &ar, VectorN<TYPE>& v)
 	// CArchive de-serialization of a vector
 {
 	// retrieve the dimension first
@@ -627,7 +627,7 @@ CArchive&
 
 	return ar;
 
-}	// operator>>(CArchive &ar, CVectorN<TYPE>& v)
+}	// operator>>(CArchive &ar, VectorN<TYPE>& v)
 
 #endif	// __AFX_H__
 
@@ -636,7 +636,7 @@ CArchive&
 #ifdef _MSC_VER
 template<class TYPE>
 void
-	LogExprExt(const CVectorN<TYPE> & vVec,
+	LogExprExt(const VectorN<TYPE> & vVec,
 			const char *pszName, const char *pszModule)
 	// helper function for XML logging of vectors
 {
@@ -674,5 +674,9 @@ void
 }	// LogExprExt
 #endif // _MSC_VER
 
+
+// Backward compatibility
+template<class TYPE = REAL>
+using CVectorN = VectorN<TYPE>;
 
 #endif	// !defined(VECTORN_H)

--- a/src/OptimizeN/include/optimize_types.h
+++ b/src/OptimizeN/include/optimize_types.h
@@ -1,0 +1,93 @@
+//////////////////////////////////////////////////////////////////////
+// optimize_types.h: Minimal compatibility types for OptimizeN
+//
+// Provides the subset of Windows/MFC types and macros that OptimizeN
+// actually needs, without pulling in CObject, CString, or other
+// MFC class stubs.
+//
+// This header is only included on non-MSVC platforms via stdafx.h.
+//////////////////////////////////////////////////////////////////////
+
+#ifndef OPTIMIZE_TYPES_H
+#define OPTIMIZE_TYPES_H
+
+#include <cassert>
+#include <cstdint>
+#include <cmath>
+
+//////////////////////////////////////////////////////////////////////
+// Windows type aliases
+//////////////////////////////////////////////////////////////////////
+
+typedef int BOOL;
+#define TRUE 1
+#define FALSE 0
+
+typedef uint32_t DWORD;
+typedef unsigned int UINT;
+
+//////////////////////////////////////////////////////////////////////
+// MSVC intrinsics / macros
+//////////////////////////////////////////////////////////////////////
+
+#ifndef __max
+#define __max(a, b) (((a) > (b)) ? (a) : (b))
+#endif
+
+#ifndef __min
+#define __min(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+
+// _finite -> std::isfinite
+#ifndef _finite
+#define _finite(x) std::isfinite(x)
+#endif
+
+// __forceinline -> inline (GCC/Clang have __attribute__((always_inline)))
+#ifndef __forceinline
+#define __forceinline inline __attribute__((always_inline))
+#endif
+
+// _T() text macro - no-op on Linux (no wide char)
+#ifndef _T
+#define _T(x) x
+#endif
+
+//////////////////////////////////////////////////////////////////////
+// Debug macros
+//////////////////////////////////////////////////////////////////////
+
+#ifdef _DEBUG
+#define ASSERT(expr) assert(expr)
+#else
+#define ASSERT(expr) ((void)0)
+#endif
+
+#define ATLASSERT(expr) ASSERT(expr)
+#define TRACE(...) ((void)0)
+#define TRACE_VECTOR(...) ((void)0)
+
+// USES_CONVERSION - ATL string conversion macro, no-op on non-MSVC
+#define USES_CONVERSION
+
+// DEBUG_NEW / THIS_FILE - used in #ifdef _DEBUG blocks
+#define DEBUG_NEW new
+
+//////////////////////////////////////////////////////////////////////
+// Serialization macro stubs - no-ops on non-MSVC
+//////////////////////////////////////////////////////////////////////
+
+#define VERSIONABLE_SCHEMA 0
+#define DECLARE_SERIAL(class_name)
+#define IMPLEMENT_SERIAL(class_name, base_class, schema)
+#define IMPLEMENT_DYNAMIC(class_name, base_class)
+#define DECLARE_DYNAMIC(class_name)
+
+//////////////////////////////////////////////////////////////////////
+// Forward declarations for serialization (guarded by #ifdef _MSC_VER)
+//////////////////////////////////////////////////////////////////////
+
+class CArchive;
+class CDumpContext;
+
+#endif // OPTIMIZE_TYPES_H

--- a/src/OptimizeN/stdafx.h
+++ b/src/OptimizeN/stdafx.h
@@ -32,7 +32,7 @@
 
 #else // !_MSC_VER (Linux/GCC/Clang)
 
-#include <mfc_compat.h>
+#include <optimize_types.h>
 
 #include <string>
 #include <vector>

--- a/src/theWheelGL/StdAfx.h
+++ b/src/theWheelGL/StdAfx.h
@@ -18,7 +18,7 @@
 #define NOMINMAX
 #include <windows.h>
 #else
-#include "mfc_compat.h"
+#include <mfc_compat.h>
 #endif
 
 // VectorD.h uses ASSERT (MFC macro) — provide a stub

--- a/src/theWheelModel/CMakeLists.txt
+++ b/src/theWheelModel/CMakeLists.txt
@@ -26,6 +26,7 @@ set(THEWHEELMODEL_HEADERS
     include/SpaceStateVector.h
     include/UpdateStamp.h
     include/VectorD.h
+    include/mfc_compat.h
     stdafx.h
 )
 

--- a/src/theWheelModel/SpaceLayoutManager.cpp
+++ b/src/theWheelModel/SpaceLayoutManager.cpp
@@ -68,7 +68,7 @@ const REAL RELAX_NEW_GAIN_FACTOR_SUBTHRESHOLD = 0.8f;
 CSpaceLayoutManager::CSpaceLayoutManager(CSpace *pSpace)
 	// constructs an energy function object for the associated space 
 	//		view
-	: CObjectiveFunction(TRUE)
+	: ObjectiveFunction(TRUE)
 	, m_pSpace(pSpace)
 
 	, m_KPos(K_POS)
@@ -95,11 +95,11 @@ CSpaceLayoutManager::CSpaceLayoutManager(CSpace *pSpace)
 	m_pStateVector = new CSpaceStateVector(this->m_pSpace);
 
 	// create and initialize the Powell optimizer
-	m_pPowellOptimizer = new CPowellOptimizer(this);
+	m_pPowellOptimizer = new PowellOptimizer(this);
 	m_pPowellOptimizer->SetTolerance(TOLERANCE);
 
 	// create and initialize the conjugate gradient optimizer
-	CConjGradOptimizer *pCGO = new CConjGradOptimizer(this);
+	ConjGradOptimizer *pCGO = new ConjGradOptimizer(this);
 	pCGO->SetLineToleranceEqual(false);
 	pCGO->SetTolerance(1e-3f);
 	pCGO->GetBrentOptimizer().SetTolerance(1e-4f);
@@ -108,7 +108,7 @@ CSpaceLayoutManager::CSpaceLayoutManager(CSpace *pSpace)
 	m_pConjGradOptimizer = pCGO;
 
 	// create and initialize the gradient descent optimizer
-	m_pGradDescOptimizer = new CGradDescOptimizer(this);
+	m_pGradDescOptimizer = new GradDescOptimizer(this);
 	m_pGradDescOptimizer->SetTolerance(TOLERANCE);
 
 	// create and initialize the dfp optimizer
@@ -293,7 +293,7 @@ void
 	m_nEvaluations = 0;
 
 	// form the partial state vector
-	CVectorN<> vPartState;
+	VectorN<> vPartState;
 	vPartState.SetElements(GetStateDim() - m_nConstNodes * 2,
 		&m_vState[m_nConstNodes * 2], FALSE);
 
@@ -514,8 +514,8 @@ void
 
 //////////////////////////////////////////////////////////////////////
 REAL 
-	CSpaceLayoutManager::operator()(const CVectorN<REAL>& vInput,
-			CVectorN<> *pGrad) const
+	CSpaceLayoutManager::operator()(const VectorN<REAL>& vInput,
+			VectorN<> *pGrad) const
 	// evaluates the energy function at the given point
 {
 	// reset the energy

--- a/src/theWheelModel/SpaceStateVector.cpp
+++ b/src/theWheelModel/SpaceStateVector.cpp
@@ -47,7 +47,7 @@ IMPLEMENT_SERIAL(CSpaceStateVector, CObject, VERSIONABLE_SCHEMA | 1);
 
 //////////////////////////////////////////////////////////////////////
 void 
-	CSpaceStateVector::GetActivationsVector(CVectorN<>& vActivations)
+	CSpaceStateVector::GetActivationsVector(VectorN<>& vActivations)
 	// accessor for the activation vector
 {
 	if (m_pSpace) 
@@ -68,7 +68,7 @@ void
 
 //////////////////////////////////////////////////////////////////////
 void 
-	CSpaceStateVector::SetActivationsVector(const CVectorN<>& vActivations)
+	CSpaceStateVector::SetActivationsVector(const VectorN<>& vActivations)
 	// sets the activation part of the state vector
 {
 	if (m_pSpace) 
@@ -89,7 +89,7 @@ void
 
 //////////////////////////////////////////////////////////////////////
 void 
-	CSpaceStateVector::GetPositionsVector(CVectorN<>& vPositions)
+	CSpaceStateVector::GetPositionsVector(VectorN<>& vPositions)
 	// accessor for the positions vector
 	/// TODO: should this be moved to CSpace???
 {
@@ -111,7 +111,7 @@ void
 
 //////////////////////////////////////////////////////////////////////
 void 
-	CSpaceStateVector::SetPositionsVector(const CVectorN<>& vPositions)
+	CSpaceStateVector::SetPositionsVector(const VectorN<>& vPositions)
 	// sets the node positions
 {
 	if (m_pSpace)
@@ -138,7 +138,7 @@ void
 
 //////////////////////////////////////////////////////////////////////
 void 
-	CSpaceStateVector::RotateTranslateTo(const CVectorN<>& vPositions)
+	CSpaceStateVector::RotateTranslateTo(const VectorN<>& vPositions)
 	// called to minimize rotate/translate error between old state
 	//		and new
 {
@@ -228,8 +228,8 @@ void
 
 	// now repopulate
 	m_vNewPositions.SetDim(m_pSpace->GetLayoutManager()->GetSuperNodeCount() * 2);
-	CVectorN<> vOldPos(3);
-	CVectorN<> vNewPos(3);
+	VectorN<> vOldPos(3);
+	VectorN<> vNewPos(3);
 	for (int nAt = 0; nAt < m_pSpace->GetLayoutManager()->GetSuperNodeCount(); nAt++)
 	{
 		// set up HG of previous position
@@ -263,16 +263,16 @@ void
 
 	if (ar.IsLoading())
 	{
-		CVectorN<double> vActivations;
+		VectorN<double> vActivations;
 		ar >> vActivations;
-		CVectorN<> vActReal;
+		VectorN<> vActReal;
 		for (int nAt = 0; nAt < vActivations.GetDim(); nAt++)
 			vActReal[nAt] = REAL(vActivations[nAt]);
 		SetActivationsVector(vActReal);
 
-		CVectorN<double> vPositions;
+		VectorN<double> vPositions;
 		ar >> vPositions;
-		CVectorN<> vPosReal;
+		VectorN<> vPosReal;
 		for (int nAt = 0; nAt < vActivations.GetDim(); nAt++)
 			vPosReal[nAt] = REAL(vActivations[nAt]);
 		SetPositionsVector(vPosReal);
@@ -281,16 +281,16 @@ void
 	}
 	else
 	{
-		CVectorN<> vActReal;
+		VectorN<> vActReal;
 		GetActivationsVector(vActReal);
-		CVectorN<double> vActivations;
+		VectorN<double> vActivations;
 		for (int nAt = 0; nAt < vActReal.GetDim(); nAt++)
 			vActivations[nAt] = vActReal[nAt];
 		ar << vActivations;
 
-		CVectorN<> vPosReal;
+		VectorN<> vPosReal;
 		GetPositionsVector(vPosReal);
-		CVectorN<double> vPositions;
+		VectorN<double> vPositions;
 		for (int nAt = 0; nAt < vPosReal.GetDim(); nAt++)
 			vPositions[nAt] = vPosReal[nAt];
 		ar << vPositions;

--- a/src/theWheelModel/include/CastVectorD.h
+++ b/src/theWheelModel/include/CastVectorD.h
@@ -29,7 +29,7 @@ public:
 	}
 
 	template<class OTHER_TYPE>
-	explicit CCastVectorD(const CVectorN<OTHER_TYPE>& vFrom)
+	explicit CCastVectorD(const VectorN<OTHER_TYPE>& vFrom)
 	{
 		if (DIM <= vFrom.GetDim())
 		{

--- a/src/theWheelModel/include/SpaceLayoutManager.h
+++ b/src/theWheelModel/include/SpaceLayoutManager.h
@@ -29,7 +29,7 @@ const int MAX_STATE_DIM = 100;
 // class that represents the energy function for a CSpaceView given
 //		its state vector
 //////////////////////////////////////////////////////////////////////
-class CSpaceLayoutManager : public CObjectiveFunction
+class CSpaceLayoutManager : public ObjectiveFunction
 {
 public:
 	// construct the energy function, given the CSpaceView to which it
@@ -79,8 +79,8 @@ public:
 	virtual void LoadSizesLinks(int nConstNodes, int nNodeCount);
 
 	// evaluates the energy function
-	virtual REAL operator()(const CVectorN<>& vInput, 
-		CVectorN<> *pGrad = NULL) const;
+	virtual REAL operator()(const VectorN<>& vInput, 
+		VectorN<> *pGrad = NULL) const;
 
 protected:
 	// pointer to the energy function's space
@@ -90,26 +90,26 @@ protected:
 	int m_nConstNodes;
 
 	// the optimizer for the layout
-	COptimizer *m_pPowellOptimizer;
-	COptimizer *m_pConjGradOptimizer;
-	COptimizer *m_pGradDescOptimizer;
-	COptimizer *m_pDFPOptimizer;
+	Optimizer *m_pPowellOptimizer;
+	Optimizer *m_pConjGradOptimizer;
+	Optimizer *m_pGradDescOptimizer;
+	Optimizer *m_pDFPOptimizer;
 
 	// pointer to the optimizer to be used
-	COptimizer *m_pOptimizer;
+	Optimizer *m_pOptimizer;
 
 	// caches energy value for the previous input vector
 	mutable REAL m_energy;
 	mutable REAL m_energyConst;
 
 	// holds the current state
-	mutable CVectorN<> m_vState;
+	mutable VectorN<> m_vState;
 
 	// holds constant positions
-	mutable CVectorN<> m_vConstPositions;
+	mutable VectorN<> m_vConstPositions;
 
 	// caches the gradient for the previous input vector
-	mutable CVectorN<> m_vGrad;
+	mutable VectorN<> m_vGrad;
 
 	// stores the view sizes for quick access
 	REAL (*m_mSS)[MAX_STATE_DIM];

--- a/src/theWheelModel/include/SpaceStateVector.h
+++ b/src/theWheelModel/include/SpaceStateVector.h
@@ -37,15 +37,15 @@ public:
 	int GetNodeCount() const;
 
 	// accessors for the activation vector
-	void GetActivationsVector(CVectorN<>& vActivation);
-	void SetActivationsVector(const CVectorN<>& vActivation);
+	void GetActivationsVector(VectorN<>& vActivation);
+	void SetActivationsVector(const VectorN<>& vActivation);
 
 	// accessors for the positions vector
-	void GetPositionsVector(CVectorN<>& vPositions);
-	void SetPositionsVector(const CVectorN<>& vPositions);
+	void GetPositionsVector(VectorN<>& vPositions);
+	void SetPositionsVector(const VectorN<>& vPositions);
 
 	// lsq fit to the other state vector
-	void RotateTranslateTo(const CVectorN<>& vMatchPositions);
+	void RotateTranslateTo(const VectorN<>& vMatchPositions);
 
 	//////////////////////////////////////////////////////////////////
 	// serialization
@@ -60,25 +60,25 @@ private:
 	CSpace *m_pSpace;
 
 	// old positions vector
-	CVectorN<> m_vOldPositions;
+	VectorN<> m_vOldPositions;
 
 	// form the Nx3 matrix of pre-coordinates (homogeneous)
-	CMatrixNxM<> m_mOldCoords;
+	MatrixNxM<> m_mOldCoords;
 
 	// the Nx3 matrix of post-coordinates
-	CMatrixNxM<> m_mNewCoords;
+	MatrixNxM<> m_mNewCoords;
 
 	// pseudo-inverse of the new coordinates
-	CMatrixNxM<> m_mNewCoords_psinv;
+	MatrixNxM<> m_mNewCoords_psinv;
 
 	// initial transform (calculated from pseudo-inverse)
-	CMatrixNxM<> m_mTransform;
+	MatrixNxM<> m_mTransform;
 
 	// helpers for SVD
-	CVectorN<> m_vSVD_w;
-	CMatrixNxM<> m_mSVD_v;
+	VectorN<> m_vSVD_w;
+	MatrixNxM<> m_mSVD_v;
 
 	// new positions vector
-	CVectorN<> m_vNewPositions;
+	VectorN<> m_vNewPositions;
 
 };	// class CSpaceStateVector

--- a/src/theWheelModel/include/mfc_compat.h
+++ b/src/theWheelModel/include/mfc_compat.h
@@ -1,9 +1,9 @@
 //////////////////////////////////////////////////////////////////////
 // mfc_compat.h: Linux/non-MSVC compatibility header
 //
-// Provides minimal replacements for MFC types, macros, and classes
-// used by OptimizeN and theWheelModel, allowing these libraries to
-// build on Linux/GCC/Clang without MFC.
+// Provides MFC class stubs (CObject, CString, CDocument, etc.)
+// needed by theWheelModel. Builds on optimize_types.h which provides
+// the basic Windows type aliases and macros.
 //
 // This header is only included on non-MSVC platforms via stdafx.h.
 //////////////////////////////////////////////////////////////////////
@@ -11,95 +11,30 @@
 #ifndef MFC_COMPAT_H
 #define MFC_COMPAT_H
 
-#include <cassert>
-#include <cstdint>
+// Base types and macros shared with OptimizeN
+#include <optimize_types.h>
+
 #include <cstdio>
 #include <cstring>
 #include <string>
 #include <algorithm>
 
 //////////////////////////////////////////////////////////////////////
-// Windows type aliases
+// Additional Windows type aliases (not needed by OptimizeN)
 //////////////////////////////////////////////////////////////////////
 
-typedef int BOOL;
-#define TRUE 1
-#define FALSE 0
-
-typedef uint32_t DWORD;
-typedef unsigned int UINT;
 typedef uint32_t COLORREF;
 typedef const char* LPCTSTR;
 
 //////////////////////////////////////////////////////////////////////
-// MSVC intrinsics / macros
-//////////////////////////////////////////////////////////////////////
-
-#ifndef __max
-#define __max(a, b) (((a) > (b)) ? (a) : (b))
-#endif
-
-#ifndef __min
-#define __min(a, b) (((a) < (b)) ? (a) : (b))
-#endif
-
-// _finite -> std::isfinite
-#include <cmath>
-#ifndef _finite
-#define _finite(x) std::isfinite(x)
-#endif
-
-// __forceinline -> inline (GCC/Clang have __attribute__((always_inline)))
-#ifndef __forceinline
-#define __forceinline inline __attribute__((always_inline))
-#endif
-
-// _T() text macro - no-op on Linux (no wide char)
-#ifndef _T
-#define _T(x) x
-#endif
-
-//////////////////////////////////////////////////////////////////////
-// Debug macros
-//////////////////////////////////////////////////////////////////////
-
-#ifdef _DEBUG
-#define ASSERT(expr) assert(expr)
-#else
-#define ASSERT(expr) ((void)0)
-#endif
-
-#define ATLASSERT(expr) ASSERT(expr)
-#define TRACE(...) ((void)0)
-#define TRACE_VECTOR(...) ((void)0)
-
-// USES_CONVERSION - ATL string conversion macro, no-op on non-MSVC
-#define USES_CONVERSION
-
-// DEBUG_NEW / THIS_FILE - used in #ifdef _DEBUG blocks
-#define DEBUG_NEW new
-
-// VERSIONABLE_SCHEMA - used in IMPLEMENT_SERIAL
-#define VERSIONABLE_SCHEMA 0
-
-//////////////////////////////////////////////////////////////////////
 // CObject - minimal base class stub
 //////////////////////////////////////////////////////////////////////
-
-class CDumpContext;
 
 class CObject
 {
 public:
     virtual ~CObject() {}
 };
-
-//////////////////////////////////////////////////////////////////////
-// CArchive - forward declaration only
-// Serialization methods are guarded with #ifdef _MSC_VER
-//////////////////////////////////////////////////////////////////////
-
-class CArchive;
 
 //////////////////////////////////////////////////////////////////////
 // CString - minimal wrapper around std::string
@@ -197,15 +132,6 @@ public:
 };
 
 //////////////////////////////////////////////////////////////////////
-// Serialization macros - no-ops on Linux
-//////////////////////////////////////////////////////////////////////
-
-#define DECLARE_SERIAL(class_name)
-#define IMPLEMENT_SERIAL(class_name, base_class, schema)
-#define IMPLEMENT_DYNAMIC(class_name, base_class)
-#define DECLARE_DYNAMIC(class_name)
-
-//////////////////////////////////////////////////////////////////////
 // CDocument - stub (CSpace inherits from it via IMPLEMENT_SERIAL)
 //////////////////////////////////////////////////////////////////////
 
@@ -237,8 +163,5 @@ typedef long HRESULT;
 #define FAILED(hr) (((HRESULT)(hr)) < 0)
 #define SUCCEEDED(hr) (((HRESULT)(hr)) >= 0)
 #endif
-
-// USES_CONVERSION - ATL string conversion macro, no-op on non-MSVC
-#define USES_CONVERSION
 
 #endif // MFC_COMPAT_H


### PR DESCRIPTION
## Summary

- **Move `mfc_compat.h`** from OptimizeN to theWheelModel — OptimizeN no longer depends on MFC stubs (CObject, CString, CDocument, etc.)
- **Create `optimize_types.h`** — minimal compatibility header with only what OptimizeN actually needs (BOOL, DWORD, __min/__max, ASSERT, serialization macro no-ops)
- **Remove `CObject` base** from `ObjectiveFunction` — it only provided a virtual destructor, which is now declared directly
- **Rename all OptimizeN classes** to drop the legacy MFC `C` prefix (e.g. `CVectorN` → `VectorN`, `COptimizer` → `Optimizer`), with backward-compatible `using` aliases for MSVC/theWheelView builds

## Test plan

- [x] `cmake --preset macos-debug` configures successfully
- [x] `cmake --build build/macos-debug` compiles with no new warnings
- [x] theWheelModelTests: 85 tests pass
- [x] theWheelWxTests: 17 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)