### PR TITLE
Render nodes with colored title band and optional image on left

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,15 +27,18 @@ endif()
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Python bindings are only available on Windows for now
-if(MSVC)
-    # Find Python before pybind11 to use modern CMake Python finding
-    find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+# Build static libraries with -fPIC so they can be linked into the Python
+# extension module (pythewheel) on Linux. No effect on MSVC.
+if(NOT MSVC)
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif()
 
-    # Configure pybind11 to use modern Python finding
+# Python bindings (pythewheel): available on Windows and on platforms where
+# Python and pybind11 can be located. pybind11 is fetched via FetchContent.
+find_package(Python3 COMPONENTS Interpreter Development QUIET)
+if(Python3_FOUND)
     set(PYBIND11_FINDPYTHON ON)
 
-    # Fetch pybind11 for Python bindings
     include(FetchContent)
     FetchContent_Declare(
       pybind11
@@ -43,6 +46,10 @@ if(MSVC)
       GIT_TAG v2.13.6
     )
     FetchContent_MakeAvailable(pybind11)
+    set(PYTHEWHEEL_AVAILABLE ON)
+else()
+    message(STATUS "Skipping pythewheel — Python3 development headers not found")
+    set(PYTHEWHEEL_AVAILABLE OFF)
 endif()
 
 # Enable testing
@@ -60,8 +67,11 @@ else()
     message(STATUS "Skipping theWheelGL — no ANGLE or EGL/GLESv2 available")
 endif()
 
-if(MSVC)
+if(PYTHEWHEEL_AVAILABLE)
     add_subdirectory ("pybind")
+endif()
+
+if(MSVC)
     add_subdirectory ("theWheelView")
     add_subdirectory ("theWheel")
 endif()

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -35,3 +35,19 @@ else()
     target_compile_definitions(pythewheel PRIVATE NOMINMAX)
     target_compile_options(pythewheel PRIVATE -Wall -Wno-unused-variable -Wno-sign-compare)
 endif()
+
+# Cross-language validation: pythewheel_torch (PyTorch port) tests against
+# the C++ pythewheel module built above. Invokes the same Python interpreter
+# pybind11 linked against so the modules are mutually importable; the test
+# itself skips gracefully if torch is not installed in that interpreter.
+if(Python3_EXECUTABLE)
+    add_test(
+        NAME pythewheel_torch_vs_cpp
+        COMMAND ${Python3_EXECUTABLE} -m pytest -v
+                ${CMAKE_CURRENT_SOURCE_DIR}/python/tests/test_vs_cpp.py
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    )
+    set_tests_properties(pythewheel_torch_vs_cpp PROPERTIES
+        ENVIRONMENT "PYTHONPATH=$<TARGET_FILE_DIR:pythewheel>:${CMAKE_CURRENT_SOURCE_DIR}/python"
+    )
+endif()

--- a/src/pybind/python/pythewheel_torch/__init__.py
+++ b/src/pybind/python/pythewheel_torch/__init__.py
@@ -1,0 +1,23 @@
+"""
+pythewheel_torch: PyTorch port of theWheel's activation and layout.
+
+The activation port is a literal transcription of CSpace::ActivateNode
+(see activation.py). The layout port is vectorized but produces the
+same scalar energy as CSpaceLayoutManager::operator() (see layout.py).
+
+Both are intended to be validated against the existing C++ pythewheel
+bindings — see ../tests/test_vs_cpp.py.
+"""
+
+from . import _constants as constants
+from .activation import ActivationModule
+from .layout import LayoutModule, pairwise_link_weights
+from .space import SpaceTensors
+
+__all__ = [
+    "ActivationModule",
+    "LayoutModule",
+    "SpaceTensors",
+    "constants",
+    "pairwise_link_weights",
+]

--- a/src/pybind/python/pythewheel_torch/_constants.py
+++ b/src/pybind/python/pythewheel_torch/_constants.py
@@ -1,0 +1,73 @@
+"""
+Constants ported from the C++ implementation.
+
+Names and values mirror the originals so cross-references stay obvious:
+- Node.cpp:          PRIM_FRAC, PROPAGATE_THRESHOLD_WEIGHT
+- NodeLink.cpp:      PROPAGATE_THRESHOLD_WEIGHT (same value)
+- Space.cpp:         PRIM_NORM_SCALE, SEC_NORM_SCALE, PROPAGATE_SCALE,
+                     PROPAGATE_ALPHA, TOTAL_ACTIVATION_FRACTION,
+                     DEFAULT_SPRING_CONST
+- Space.h:           TOTAL_ACTIVATION
+- SpaceLayoutManager.cpp:
+                     K_POS, K_REP, SIZE_SCALE, DIST_SCALE_MIN/MAX,
+                     ACTIVATION_MIDPOINT, MIDWEIGHT, OPT_DIST
+"""
+
+# --- Activation -------------------------------------------------------------
+
+# Fraction of an explicit SetActivation delta that goes to primary activation;
+# remainder goes to secondary. Both Node.cpp and Space.cpp use 0.5.
+PRIM_FRAC = 0.5
+
+# Links with weight at or below this threshold do not propagate.
+PROPAGATE_THRESHOLD_WEIGHT = 0.01
+
+# Initial scale and per-recursion attenuation applied during spreading
+# activation. The C++ uses these in CSpace::ActivateNode.
+PROPAGATE_SCALE = 0.40
+PROPAGATE_ALPHA = 0.99
+
+# Target sum for NormalizeNodes — equals TOTAL_ACTIVATION * TOTAL_ACTIVATION_FRACTION
+# multiplied through the activation curve. The activation cap in ActivateNode
+# is also TOTAL_ACTIVATION * TOTAL_ACTIVATION_FRACTION.
+TOTAL_ACTIVATION = 0.75
+TOTAL_ACTIVATION_FRACTION = 0.40
+
+# NormalizeNodes scales each node's primary/secondary by these multipliers
+# times the normalization delta. Values match Space.cpp (0.020*3.5, 0.060*3.5).
+PRIM_NORM_SCALE = 0.020 * 3.5
+SEC_NORM_SCALE = 0.060 * 3.5
+
+# Stabilizer links attenuate target activation by this factor and drop the
+# source node identity (so PropagateActivation does not chain from the source).
+STABILIZER_ATTENUATION = 0.25
+
+# Default sum NormalizeNodes targets when no explicit value is supplied.
+DEFAULT_NORMALIZE_SUM = 1.0
+
+
+# --- Layout -----------------------------------------------------------------
+
+# Multiplier on each node's radius before adding the floor of 10.0.
+SIZE_SCALE = 150.0
+
+# Optimal normalized distance between linked nodes (the dist_error target).
+# Derivation lives in SpaceLayoutManager.cpp; reproduced here so the
+# constants stay in one place.
+DIST_SCALE_MIN = 1.0
+DIST_SCALE_MAX = 1.35
+ACTIVATION_MIDPOINT = 0.25
+MIDWEIGHT = 0.5
+OPT_DIST = DIST_SCALE_MIN + (DIST_SCALE_MAX - DIST_SCALE_MIN) * (
+    1.0 - MIDWEIGHT / (MIDWEIGHT + ACTIVATION_MIDPOINT)
+)
+
+# Attraction and repulsion weights in the layout energy.
+K_POS = 600.0
+K_REP = 3200.0
+
+# Epsilons embedded in the energy expression (kept here so tests can poke them).
+ENERGY_DIST_EPS = 0.001   # added inside sqrt for act_dist
+ENERGY_REP_EPS = 3.0      # added to denominator of repulsion term
+LINK_WEIGHT_EPS = 1.0e-6  # added to the per-pair link weight
+SIZE_FLOOR = 10.0         # added to size after SIZE_SCALE * radius

--- a/src/pybind/python/pythewheel_torch/activation.py
+++ b/src/pybind/python/pythewheel_torch/activation.py
@@ -1,0 +1,203 @@
+"""
+ActivationModule: bit-for-bit port of CSpace::ActivateNode.
+
+The C++ algorithm is a DFS through the link graph with a per-link
+HasPropagated guard and depth-attenuated init_scale. Because the read of
+each source/target activation comes from the stable pre-cycle primary +
+secondary values (CNode mutates only m_newSecondaryActivation during the
+cycle), the DFS is order-sensitive only in *which* links it visits — not
+in the activation deltas computed per visit. We mirror the recursion
+literally with Python; the tensor state lives in SpaceTensors.
+
+Vectorization is intentionally not done here: this module's job is to be
+a faithful oracle / differentiable transcription of the C++ logic. A
+vectorized cousin would live alongside it.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from torch import nn
+
+from ._constants import (
+    DEFAULT_NORMALIZE_SUM,
+    PRIM_FRAC,
+    PRIM_NORM_SCALE,
+    PROPAGATE_ALPHA,
+    PROPAGATE_SCALE,
+    PROPAGATE_THRESHOLD_WEIGHT,
+    SEC_NORM_SCALE,
+    STABILIZER_ATTENUATION,
+    TOTAL_ACTIVATION,
+    TOTAL_ACTIVATION_FRACTION,
+)
+from .space import SpaceTensors
+
+
+class ActivationModule(nn.Module):
+    """One full CSpace::ActivateNode cycle as an nn.Module.
+
+    Stateless w.r.t. learnable parameters in this sketch — primary/secondary
+    activations live on the supplied SpaceTensors and are mutated in place.
+    A natural extension is to expose a learnable scalar gain on PROPAGATE_SCALE
+    or per-edge multipliers; both fit cleanly under torch.autograd.
+    """
+
+    def __init__(
+        self,
+        prim_frac: float = PRIM_FRAC,
+        propagate_scale: float = PROPAGATE_SCALE,
+        propagate_alpha: float = PROPAGATE_ALPHA,
+        propagate_threshold_weight: float = PROPAGATE_THRESHOLD_WEIGHT,
+        total_activation_cap: float = TOTAL_ACTIVATION * TOTAL_ACTIVATION_FRACTION,
+        prim_norm_scale: float = PRIM_NORM_SCALE,
+        sec_norm_scale: float = SEC_NORM_SCALE,
+        stabilizer_attenuation: float = STABILIZER_ATTENUATION,
+    ) -> None:
+        super().__init__()
+        self.prim_frac = prim_frac
+        self.propagate_scale = propagate_scale
+        self.propagate_alpha = propagate_alpha
+        self.propagate_threshold_weight = propagate_threshold_weight
+        self.total_activation_cap = total_activation_cap
+        self.prim_norm_scale = prim_norm_scale
+        self.sec_norm_scale = sec_norm_scale
+        self.stabilizer_attenuation = stabilizer_attenuation
+
+    # ------------------------------------------------------------------ API
+
+    def forward(
+        self,
+        space: SpaceTensors,
+        node_index: int,
+        scale: float,
+        normalize_sum: float = DEFAULT_NORMALIZE_SUM,
+    ) -> SpaceTensors:
+        """Apply ActivateNode + NormalizeNodes to `space` in place.
+
+        Returns the same SpaceTensors for chaining.
+        """
+        self._set_activation_explicit(space, node_index, self._cap(space, node_index, scale))
+        new_secondary = space.secondary_activation.clone()
+        self._propagate(
+            space=space,
+            new_secondary=new_secondary,
+            from_idx=node_index,
+            delta_activation=0.0,
+            init_scale=self.propagate_scale,
+            alpha=self.propagate_alpha,
+            propagated=torch.zeros(space.e, dtype=torch.bool),
+        )
+        space.secondary_activation = new_secondary
+        self._normalize(space, normalize_sum)
+        return space
+
+    # --------------------------------------------------------- ActivateNode
+
+    def _cap(self, space: SpaceTensors, node_index: int, scale: float) -> float:
+        """Mirrors the activation-cap line in CSpace::ActivateNode."""
+        old = float(space.activation()[node_index].item())
+        return old + scale * (self.total_activation_cap - old)
+
+    def _set_activation_explicit(
+        self, space: SpaceTensors, node_index: int, new_activation: float
+    ) -> None:
+        """Mirrors CNode::SetActivation with pActivator == NULL."""
+        old = float(space.activation()[node_index].item())
+        delta = new_activation - old
+        space.primary_activation[node_index] += self.prim_frac * delta
+        space.secondary_activation[node_index] += (1.0 - self.prim_frac) * delta
+
+    # ----------------------------------------------------- PropagateActivation
+
+    def _propagate(
+        self,
+        space: SpaceTensors,
+        new_secondary: torch.Tensor,
+        from_idx: int,
+        delta_activation: float,
+        init_scale: float,
+        alpha: float,
+        propagated: torch.Tensor,
+    ) -> None:
+        """Literal DFS port of CNode::PropagateActivation.
+
+        `new_secondary` is the in-progress accumulator (matches m_newSecondaryActivation).
+        `propagated` is the per-edge HasPropagated flag, reset per ActivateNode cycle.
+        """
+        # Accumulate into the destination's new_secondary if positive.
+        if delta_activation > 0.0:
+            new_secondary[from_idx] = new_secondary[from_idx] + delta_activation
+
+        # Recurse through each outgoing link of from_idx in C++ order.
+        for edge in space.links_from(from_idx):
+            self._propagate_link(
+                space=space,
+                new_secondary=new_secondary,
+                edge_idx=int(edge.item()),
+                source_idx=from_idx,
+                init_scale=init_scale,
+                alpha=alpha,
+                propagated=propagated,
+            )
+
+    def _propagate_link(
+        self,
+        space: SpaceTensors,
+        new_secondary: torch.Tensor,
+        edge_idx: int,
+        source_idx: int,
+        init_scale: float,
+        alpha: float,
+        propagated: torch.Tensor,
+    ) -> None:
+        """Literal DFS port of CNodeLink::PropagateActivation."""
+        if propagated[edge_idx]:
+            return
+        weight = float(space.edge_weight[edge_idx].item())
+        if weight <= self.propagate_threshold_weight:
+            return
+        propagated[edge_idx] = True
+
+        target_idx = int(space.edge_index[1, edge_idx].item())
+        # Source / target reads use the pre-cycle activation (primary + secondary),
+        # NOT the in-progress new_secondary. This is critical: the C++ never
+        # reads m_newSecondaryActivation during propagation.
+        source_act = float(space.activation()[source_idx].item())
+        target_activation = source_act * weight
+
+        is_stabilizer = bool(space.edge_is_stabilizer[edge_idx].item())
+        if is_stabilizer:
+            target_activation *= self.stabilizer_attenuation
+
+        target_act = float(space.activation()[target_idx].item())
+        delta = (target_activation - target_act) * init_scale * weight
+
+        self._propagate(
+            space=space,
+            new_secondary=new_secondary,
+            from_idx=target_idx,
+            delta_activation=delta,
+            init_scale=init_scale * alpha,
+            alpha=alpha,
+            propagated=propagated,
+        )
+
+    # --------------------------------------------------------- NormalizeNodes
+
+    def _normalize(self, space: SpaceTensors, sum_target: float) -> None:
+        """Mirrors CSpace::NormalizeNodes(sum)."""
+        total = float(space.activation().sum().item())
+        if total <= 0.0:
+            return
+        diff_frac = sum_target / total - 1.0
+        if diff_frac > 0.0:
+            diff_frac = 0.0
+        space.primary_activation = space.primary_activation + (
+            space.primary_activation * diff_frac * self.prim_norm_scale
+        )
+        space.secondary_activation = space.secondary_activation + (
+            space.secondary_activation * diff_frac * self.sec_norm_scale
+        )

--- a/src/pybind/python/pythewheel_torch/layout.py
+++ b/src/pybind/python/pythewheel_torch/layout.py
@@ -1,0 +1,226 @@
+"""
+LayoutModule: port of CSpaceLayoutManager's energy function and optimizer.
+
+The C++ side runs Powell / Conjugate Gradient over the same pairwise
+energy. Here we use torch.optim.LBFGS, which is the closest equivalent in
+PyTorch (also a quasi-Newton, also expects a closure). The energy itself
+is vectorized using broadcasted pairwise tensors — this part is *not* a
+literal transcription; it produces the same value but exploits torch
+parallelism.
+
+Per-pair link weight matches LoadSizesLinks:
+    avg_act[i,j] = a_i + a_j
+    weight[i,j]  = (a_i / avg_act * gain_i_to_j + a_j / avg_act * gain_j_to_i
+                    + LINK_WEIGHT_EPS) * avg_act
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import torch
+from torch import nn
+
+from ._constants import (
+    ENERGY_DIST_EPS,
+    ENERGY_REP_EPS,
+    K_POS,
+    K_REP,
+    LINK_WEIGHT_EPS,
+    OPT_DIST,
+    SIZE_FLOOR,
+    SIZE_SCALE,
+)
+from .space import SpaceTensors
+
+
+def _pairwise_gain_matrix(space: SpaceTensors) -> torch.Tensor:
+    """Build a dense (N, N) gain matrix from the directed edge list.
+
+    `gain[i, j]` is the CNodeLink::GetGain() from i to j, or 0.0 if no edge.
+    """
+    n = space.n
+    g = torch.zeros(n, n, dtype=space.edge_weight.dtype)
+    if space.e == 0:
+        return g
+    src = space.edge_index[0]
+    dst = space.edge_index[1]
+    g[src, dst] = space.edge_gain
+    return g
+
+
+def pairwise_link_weights(
+    activations: torch.Tensor, gain: torch.Tensor
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Compute (avg_act, link_weight) over all (i, j) pairs.
+
+    Matches LoadSizesLinks. Returns dense (N, N) tensors that the caller
+    typically masks to the upper triangle.
+    """
+    n = activations.shape[0]
+    a_i = activations.view(n, 1).expand(n, n)
+    a_j = activations.view(1, n).expand(n, n)
+    avg = a_i + a_j
+    # Avoid div-by-zero for inactive pairs. We mask out i==j and pairs with
+    # avg==0 downstream, so the value here only matters for finiteness.
+    safe_avg = torch.where(avg > 0, avg, torch.ones_like(avg))
+    weight = (
+        a_i / safe_avg * gain + a_j / safe_avg * gain.t() + LINK_WEIGHT_EPS
+    ) * avg
+    weight = torch.where(avg > 0, weight, torch.zeros_like(weight))
+    return avg, weight
+
+
+class LayoutModule(nn.Module):
+    """Force-directed layout energy as an nn.Module.
+
+    positions is exposed as an nn.Parameter so torch.optim works directly.
+    The energy mirrors CSpaceLayoutManager::operator() — attraction is
+    K_POS * weight * (act_dist - OPT_DIST)^2 and repulsion is
+    K_REP * avg_act / (x_ratio + y_ratio + ENERGY_REP_EPS).
+    """
+
+    def __init__(
+        self,
+        space: SpaceTensors,
+        k_pos: float = K_POS,
+        k_rep: float = K_REP,
+        size_scale: float = SIZE_SCALE,
+        size_floor: float = SIZE_FLOOR,
+        opt_dist: float = OPT_DIST,
+        dist_eps: float = ENERGY_DIST_EPS,
+        rep_eps: float = ENERGY_REP_EPS,
+    ) -> None:
+        super().__init__()
+        self.space = space
+        self.k_pos = k_pos
+        self.k_rep = k_rep
+        self.size_scale = size_scale
+        self.size_floor = size_floor
+        self.opt_dist = opt_dist
+        self.dist_eps = dist_eps
+        self.rep_eps = rep_eps
+
+        # Learnable parameter: 2D positions per node.
+        self.positions = nn.Parameter(space.positions.clone())
+
+        # Precomputed / fixed-per-call buffers. These are derived from the
+        # current activation snapshot — the C++ recomputes them inside
+        # LoadSizesLinks before each call. If you call layout multiple
+        # times across activation changes, rebuild via refresh_from_space().
+        self.register_buffer("_sizes", torch.empty(0))
+        self.register_buffer("_avg_act", torch.empty(0))
+        self.register_buffer("_link_weight", torch.empty(0))
+        self.refresh_from_space()
+
+    # ------------------------------------------------------------------ API
+
+    def refresh_from_space(self) -> None:
+        """Recompute the per-pair size/activation/weight matrices.
+
+        Mirrors LoadSizesLinks. Call this whenever activations change
+        between layout runs.
+        """
+        sp = self.space
+        sizes = self.size_scale * sp.radii + self.size_floor
+        gain = _pairwise_gain_matrix(sp)
+        avg_act, link_weight = pairwise_link_weights(sp.activation(), gain)
+
+        # Mask to upper triangle (i < j) — the C++ iterates each pair once
+        # in its outer/inner loops.
+        n = sp.n
+        triu = torch.triu(torch.ones(n, n, dtype=torch.bool), diagonal=1)
+        avg_act = torch.where(triu, avg_act, torch.zeros_like(avg_act))
+        link_weight = torch.where(triu, link_weight, torch.zeros_like(link_weight))
+
+        self._sizes = sizes
+        self._avg_act = avg_act
+        self._link_weight = link_weight
+
+    def forward(self) -> torch.Tensor:
+        """Return the scalar layout energy at the current positions."""
+        pos = self.positions
+        n = pos.shape[0]
+
+        # Pairwise displacements (i, j) for i, j in [0, N).
+        x = pos[:, 0].view(n, 1) - pos[:, 0].view(1, n)
+        y = pos[:, 1].view(n, 1) - pos[:, 1].view(1, n)
+
+        # Note: the C++ uses the average of the two node sizes squared
+        # *as a single number* in both x and y denominators (the same ss
+        # is reused as ssx_sq and ssy_sq) — see SpaceLayoutManager.cpp.
+        # We mirror that here.
+        s_i = self._sizes.view(n, 1)
+        s_j = self._sizes.view(1, n)
+        ss = (s_i + s_j) * 0.5
+        ss_sq = ss * ss
+        # Guard against ss_sq == 0 (shouldn't happen with SIZE_FLOOR>0,
+        # but be safe under autograd).
+        ss_sq = torch.where(ss_sq > 0, ss_sq, torch.ones_like(ss_sq))
+
+        x_ratio = x * x / ss_sq
+        y_ratio = y * y / ss_sq
+        rsq = x_ratio + y_ratio
+
+        act_dist = torch.sqrt(rsq + self.dist_eps)
+        dist_error = act_dist - self.opt_dist
+
+        # Attraction: factor = K_POS * link_weight ; energy += factor * dist_error^2
+        attr = self.k_pos * self._link_weight * dist_error * dist_error
+
+        # Repulsion: factor_rep = K_REP * avg_act ; energy += factor_rep / (rsq + 3.0)
+        rep = self.k_rep * self._avg_act / (rsq + self.rep_eps)
+
+        # Sum upper triangle — _link_weight and _avg_act are already
+        # zeroed below the diagonal in refresh_from_space().
+        return attr.sum() + rep.sum()
+
+    def optimize(
+        self,
+        n_steps: int = 100,
+        lr: float = 1.0,
+        optimizer: str = "adam",
+    ) -> float:
+        """Run `n_steps` optimization steps; return the final energy.
+
+        `optimizer` selects the algorithm:
+          - "adam":  torch.optim.Adam (default; robust on this non-convex
+                     pairwise energy, similar role to a damped gradient
+                     descent in spirit).
+          - "lbfgs": torch.optim.LBFGS with strong_wolfe line search. Closer
+                     in spirit to the C++ Powell / Conjugate Gradient path,
+                     but more sensitive to initial conditions on this
+                     landscape — pick lr carefully and/or wrap in a loop.
+        """
+        if optimizer == "adam":
+            opt = torch.optim.Adam([self.positions], lr=lr)
+            e = self.forward()
+            for _ in range(n_steps):
+                opt.zero_grad()
+                e = self.forward()
+                e.backward()
+                opt.step()
+            return float(e.item())
+        elif optimizer == "lbfgs":
+            opt = torch.optim.LBFGS(
+                [self.positions],
+                lr=lr,
+                max_iter=n_steps,
+                line_search_fn="strong_wolfe",
+            )
+
+            def closure() -> torch.Tensor:
+                opt.zero_grad()
+                e = self.forward()
+                e.backward()
+                return e
+
+            e_final = opt.step(closure)
+            return float(e_final.item())
+        else:
+            raise ValueError(f"unknown optimizer: {optimizer!r}")
+
+    def write_positions_to_space(self) -> None:
+        """Copy current positions back into the SpaceTensors snapshot."""
+        with torch.no_grad():
+            self.space.positions = self.positions.detach().clone()

--- a/src/pybind/python/pythewheel_torch/space.py
+++ b/src/pybind/python/pythewheel_torch/space.py
@@ -1,0 +1,165 @@
+"""
+SpaceTensors: dataclass holding the per-node and per-link state needed by
+ActivationModule and LayoutModule.
+
+All tensors are 1-D over nodes or 2-D (E, 2) over directed edges. Activations
+use float32 to match the C++ REAL alias on this codebase.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import torch
+
+
+@dataclass
+class SpaceTensors:
+    """Tensor view of a CSpace, suitable for PyTorch modules.
+
+    Attributes mirror the C++ representation:
+        primary_activation:    (N,) float, mirrors CNode::m_primaryActivation
+        secondary_activation:  (N,) float, mirrors CNode::m_secondaryActivation
+        positions:             (N, 2) float, world-space xy
+        radii:                 (N,) float, CNode::GetRadius()
+        edge_index:            (2, E) long, [source, target] per directed edge.
+                               Order within each source matches the C++ link
+                               order, which matters for the DFS PropagateActivation
+                               since the per-link HasPropagated flag short-circuits.
+        edge_weight:           (E,) float, CNodeLink::GetWeight()
+        edge_gain:             (E,) float, CNodeLink::GetGain()
+        edge_is_stabilizer:    (E,) bool
+    """
+
+    primary_activation: torch.Tensor
+    secondary_activation: torch.Tensor
+    positions: torch.Tensor
+    radii: torch.Tensor
+    edge_index: torch.Tensor
+    edge_weight: torch.Tensor
+    edge_gain: torch.Tensor
+    edge_is_stabilizer: torch.Tensor
+
+    # Cached per-source [start, end) slices into edge_index for fast lookup.
+    _edge_offsets: Optional[torch.Tensor] = field(default=None, repr=False)
+
+    @property
+    def n(self) -> int:
+        return int(self.primary_activation.shape[0])
+
+    @property
+    def e(self) -> int:
+        return int(self.edge_index.shape[1])
+
+    def activation(self) -> torch.Tensor:
+        """Total activation per node (matches CNode::GetActivation())."""
+        return self.primary_activation + self.secondary_activation
+
+    def links_from(self, source: int) -> torch.Tensor:
+        """Edge indices whose source is `source`, in their original C++ order.
+
+        Returned indices are into edge_weight / edge_is_stabilizer / etc.
+        """
+        if self._edge_offsets is None:
+            self._build_edge_offsets()
+        start = int(self._edge_offsets[source].item())
+        end = int(self._edge_offsets[source + 1].item())
+        return torch.arange(start, end, dtype=torch.long)
+
+    def _build_edge_offsets(self) -> None:
+        # Compute a CSR-style offsets vector for the directed adjacency,
+        # assuming edge_index is grouped by source. (build_from_pythewheel
+        # produces edges in that order; if a caller hands in unsorted edges,
+        # this will misbehave — the docstring says so.)
+        n = self.n
+        offsets = torch.zeros(n + 1, dtype=torch.long)
+        if self.e > 0:
+            src = self.edge_index[0]
+            for i in range(self.e):
+                s = int(src[i].item())
+                offsets[s + 1] += 1
+        self._edge_offsets = torch.cumsum(offsets, dim=0)
+
+    # ------------------------------------------------------------------ I/O
+
+    @staticmethod
+    def from_pythewheel(cspace) -> "SpaceTensors":
+        """Build a SpaceTensors snapshot from a pythewheel.Space.
+
+        The C++ Space owns its CNode/CNodeLink objects; this just reads their
+        current state into tensors. Pure copy — no live binding back.
+        """
+        n = cspace.get_node_count()
+        prim = torch.zeros(n, dtype=torch.float32)
+        sec = torch.zeros(n, dtype=torch.float32)
+        pos = torch.zeros(n, 2, dtype=torch.float32)
+        rad = torch.zeros(n, dtype=torch.float32)
+
+        # Map CNode object identity to index so we can resolve link targets.
+        node_to_idx = {}
+        nodes = []
+        for i in range(n):
+            node = cspace.get_node_at(i)
+            nodes.append(node)
+            # Use id() since the C++ NodeLink.get_target returns the same
+            # Python wrapper object across calls (return_value_policy::reference).
+            node_to_idx[id(node)] = i
+            prim[i] = node.get_primary_activation()
+            sec[i] = node.get_secondary_activation()
+            p = node.get_position()
+            pos[i, 0] = p[0]
+            pos[i, 1] = p[1]
+            rad[i] = node.get_radius()
+
+        src_list, dst_list, w_list, g_list, stab_list = [], [], [], [], []
+        for i, node in enumerate(nodes):
+            for k in range(node.get_link_count()):
+                link = node.get_link_at(k)
+                target = link.get_target()
+                tid = id(target)
+                if tid not in node_to_idx:
+                    # Link target is outside the space's node array (the
+                    # hidden root or an external node). Skip — the C++
+                    # SortNodes pipeline normally keeps everything in the
+                    # array, but be defensive.
+                    continue
+                src_list.append(i)
+                dst_list.append(node_to_idx[tid])
+                w_list.append(link.get_weight())
+                g_list.append(link.get_gain())
+                stab_list.append(bool(link.is_stabilizer()))
+
+        if src_list:
+            edge_index = torch.tensor([src_list, dst_list], dtype=torch.long)
+            edge_weight = torch.tensor(w_list, dtype=torch.float32)
+            edge_gain = torch.tensor(g_list, dtype=torch.float32)
+            edge_stab = torch.tensor(stab_list, dtype=torch.bool)
+        else:
+            edge_index = torch.zeros(2, 0, dtype=torch.long)
+            edge_weight = torch.zeros(0, dtype=torch.float32)
+            edge_gain = torch.zeros(0, dtype=torch.float32)
+            edge_stab = torch.zeros(0, dtype=torch.bool)
+
+        return SpaceTensors(
+            primary_activation=prim,
+            secondary_activation=sec,
+            positions=pos,
+            radii=rad,
+            edge_index=edge_index,
+            edge_weight=edge_weight,
+            edge_gain=edge_gain,
+            edge_is_stabilizer=edge_stab,
+        )
+
+    def clone(self) -> "SpaceTensors":
+        return SpaceTensors(
+            primary_activation=self.primary_activation.clone(),
+            secondary_activation=self.secondary_activation.clone(),
+            positions=self.positions.clone(),
+            radii=self.radii.clone(),
+            edge_index=self.edge_index.clone(),
+            edge_weight=self.edge_weight.clone(),
+            edge_gain=self.edge_gain.clone(),
+            edge_is_stabilizer=self.edge_is_stabilizer.clone(),
+        )

--- a/src/pybind/python/tests/test_vs_cpp.py
+++ b/src/pybind/python/tests/test_vs_cpp.py
@@ -1,0 +1,209 @@
+"""
+Cross-language validation of pythewheel_torch against the C++ pythewheel
+bindings (the oracle).
+
+The C++ module is built into <build>/python/pythewheel.cpython-*.so. The
+test harness prepends that directory to sys.path so the tests run from a
+plain pytest invocation.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+# --- locate the C++ pythewheel module ---------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_PYTHON_DIRS = [
+    _REPO_ROOT / "build" / "linux-debug" / "python",
+    _REPO_ROOT / "build" / "macos-debug" / "python",
+    _REPO_ROOT / "build" / "x64-debug" / "python",
+]
+for _d in _PYTHON_DIRS:
+    if _d.is_dir():
+        sys.path.insert(0, str(_d))
+
+# Also let tests import the sibling pythewheel_torch package without an
+# install step.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+try:
+    import pythewheel as pw  # noqa: E402  (the C++ oracle)
+except ImportError:
+    pw = None
+
+import pythewheel_torch as pwt  # noqa: E402
+
+
+pytestmark = pytest.mark.skipif(
+    pw is None,
+    reason="C++ pythewheel module not built; run `cmake --build ... --target pythewheel` first",
+)
+
+
+# ----------------------------------------------------------------- fixtures
+
+
+def build_simple_cpp_space():
+    """A small directed-link space with a known shape.
+
+    Hierarchy: hidden_root -> {a, b, c, d}
+    Links: a<->b (w=0.5), a<->c (w=0.3), b<->d (w=0.4), c<->d (w=0.2)
+    All bidirectional; a starts at 0.4 activation, others at 0.1.
+    """
+    s = pw.Space()
+    nodes = []
+    for name in ("a", "b", "c", "d"):
+        n = pw.Node(s, name, "")
+        s.add_node(n)
+        nodes.append(n)
+    a, b, c, d = nodes
+
+    # Reset activations to known starting values. SetActivation goes through
+    # the primary/secondary split, so use it directly.
+    for n in nodes:
+        n.set_activation(0.1)
+    a.set_activation(0.4)
+
+    a.link_to(b, 0.5, True)
+    a.link_to(c, 0.3, True)
+    b.link_to(d, 0.4, True)
+    c.link_to(d, 0.2, True)
+
+    return s, nodes
+
+
+def snapshot_cpp(space):
+    """Return (primary, secondary, total) tensors over space's nodes."""
+    n = space.get_node_count()
+    prim = torch.zeros(n, dtype=torch.float32)
+    sec = torch.zeros(n, dtype=torch.float32)
+    for i in range(n):
+        nd = space.get_node_at(i)
+        prim[i] = nd.get_primary_activation()
+        sec[i] = nd.get_secondary_activation()
+    return prim, sec, prim + sec
+
+
+# ------------------------------------------------------------- activation ---
+
+
+def test_activation_matches_cpp():
+    """One ActivateNode cycle in PyTorch matches the C++ oracle."""
+    cpp_space, cpp_nodes = build_simple_cpp_space()
+    torch_space = pwt.SpaceTensors.from_pythewheel(cpp_space)
+
+    # Sanity: snapshots agree before the activation step.
+    prim0, sec0, _ = snapshot_cpp(cpp_space)
+    assert torch.allclose(torch_space.primary_activation, prim0, atol=1e-6)
+    assert torch.allclose(torch_space.secondary_activation, sec0, atol=1e-6)
+
+    # Run ActivateNode on index 0 (= 'a') with scale=0.5 in both worlds.
+    cpp_space.activate_node(cpp_nodes[0], 0.5)
+    module = pwt.ActivationModule()
+    module(torch_space, node_index=0, scale=0.5)
+
+    cpp_prim, cpp_sec, cpp_total = snapshot_cpp(cpp_space)
+
+    # Bit-for-bit match isn't realistic (float ordering differs slightly
+    # between the C++ inline math and the per-step Python tensor ops), but
+    # the values should agree to ~1e-5 absolute.
+    assert torch.allclose(
+        torch_space.primary_activation, cpp_prim, atol=1e-5
+    ), (torch_space.primary_activation, cpp_prim)
+    assert torch.allclose(
+        torch_space.secondary_activation, cpp_sec, atol=1e-5
+    ), (torch_space.secondary_activation, cpp_sec)
+    assert torch.allclose(
+        torch_space.activation(), cpp_total, atol=1e-5
+    )
+
+
+def test_activation_repeated_cycles():
+    """Multiple sequential ActivateNode cycles still match."""
+    cpp_space, cpp_nodes = build_simple_cpp_space()
+    torch_space = pwt.SpaceTensors.from_pythewheel(cpp_space)
+    module = pwt.ActivationModule()
+
+    for target_idx, scale in [(0, 0.5), (3, 0.3), (1, 0.2), (2, 0.4)]:
+        cpp_space.activate_node(cpp_nodes[target_idx], scale)
+        module(torch_space, node_index=target_idx, scale=scale)
+
+    cpp_prim, cpp_sec, cpp_total = snapshot_cpp(cpp_space)
+    assert torch.allclose(torch_space.primary_activation, cpp_prim, atol=1e-4)
+    assert torch.allclose(torch_space.secondary_activation, cpp_sec, atol=1e-4)
+    assert torch.allclose(torch_space.activation(), cpp_total, atol=1e-4)
+
+
+# ----------------------------------------------------------------- layout ---
+
+
+def test_layout_energy_finite_and_decreases():
+    """LBFGS reduces the layout energy from a perturbed initial state."""
+    cpp_space, _ = build_simple_cpp_space()
+    # Give the nodes nontrivial positions so the energy isn't trivially zero.
+    # NOTE: pythewheel.Node.get_position returns a *copy*, so we must build
+    # a fresh Vector3D and pass it to set_position.
+    for i in range(cpp_space.get_node_count()):
+        nd = cpp_space.get_node_at(i)
+        nd.set_position(pw.Vector3D(50.0 * (i - 1.5), 30.0 * ((i % 2) * 2 - 1), 0.0))
+
+    torch_space = pwt.SpaceTensors.from_pythewheel(cpp_space)
+    layout = pwt.LayoutModule(torch_space)
+
+    e0 = layout.forward().item()
+    assert torch.isfinite(torch.tensor(e0)), f"initial energy not finite: {e0}"
+
+    e_final = layout.optimize(n_steps=50)
+    assert e_final < e0, f"layout failed to reduce energy: {e0} -> {e_final}"
+
+
+def test_layout_gradient_flows_to_positions():
+    """positions should be a leaf with a gradient after a backward pass."""
+    cpp_space, _ = build_simple_cpp_space()
+    # Give the nodes nontrivial positions; (0,0)-everywhere collapses all
+    # pairwise displacements to zero and yields a zero gradient.
+    for i in range(cpp_space.get_node_count()):
+        nd = cpp_space.get_node_at(i)
+        nd.set_position(pw.Vector3D(50.0 * (i - 1.5), 30.0 * ((i % 2) * 2 - 1), 0.0))
+    torch_space = pwt.SpaceTensors.from_pythewheel(cpp_space)
+    layout = pwt.LayoutModule(torch_space)
+
+    energy = layout()
+    energy.backward()
+
+    assert layout.positions.grad is not None
+    assert layout.positions.grad.shape == layout.positions.shape
+    # Some nodes carry nonzero gradient — otherwise the optimizer can't move.
+    assert layout.positions.grad.abs().sum().item() > 0
+
+
+def test_pairwise_link_weight_matches_loadsizeslinks():
+    """The pairwise_link_weights helper reproduces the C++ LoadSizesLinks formula."""
+    cpp_space, _ = build_simple_cpp_space()
+    torch_space = pwt.SpaceTensors.from_pythewheel(cpp_space)
+
+    from pythewheel_torch.layout import _pairwise_gain_matrix
+
+    gain = _pairwise_gain_matrix(torch_space)
+    avg, weight = pwt.pairwise_link_weights(torch_space.activation(), gain)
+
+    # Spot-check (a, b): a_i, a_j are a's and b's totals; gain_ij and gain_ji
+    # come from the link's GetGain. The formula is symmetric in (i,j).
+    a_idx, b_idx = 0, 1
+    a_i = float(torch_space.activation()[a_idx].item())
+    a_j = float(torch_space.activation()[b_idx].item())
+    g_ij = float(gain[a_idx, b_idx].item())
+    g_ji = float(gain[b_idx, a_idx].item())
+    expected_avg = a_i + a_j
+    expected_w = (
+        a_i / expected_avg * g_ij + a_j / expected_avg * g_ji + pwt.constants.LINK_WEIGHT_EPS
+    ) * expected_avg
+
+    assert avg[a_idx, b_idx].item() == pytest.approx(expected_avg, abs=1e-6)
+    assert weight[a_idx, b_idx].item() == pytest.approx(expected_w, abs=1e-6)

--- a/src/theWheelModel/include/mfc_compat.h
+++ b/src/theWheelModel/include/mfc_compat.h
@@ -14,6 +14,7 @@
 // Base types and macros shared with OptimizeN
 #include <optimize_types.h>
 
+#include <cstdarg>
 #include <cstdio>
 #include <cstring>
 #include <string>

--- a/src/theWheelWx/SpacePanel.cpp
+++ b/src/theWheelWx/SpacePanel.cpp
@@ -9,17 +9,24 @@
 #include "SpacePanel.h"
 #include "SpaceTreeView.h"
 #include <wx/dcbuffer.h>
+#include <wx/image.h>
+#include <wx/filename.h>
 #include <NodeLink.h>
 #include <cmath>
 #ifdef USE_OPENGL_RENDERER
 #include <wx/dcclient.h>
 #endif
 
-// Colors matching the original GDI rendering
-static const wxColour BG_COLOR(232, 232, 232);
-static const wxColour LINK_COLOR(100, 100, 160);
-static const wxColour NODE_BORDER_LIGHT(255, 255, 255);
-static const wxColour NODE_BORDER_DARK(128, 128, 128);
+// Legacy theWheel color palette (mirrors NodeViewSkin.cpp / NodeView.cpp).
+// These match the original GDI renderer: a light gray body with a beveled
+// outline (light upper-left, dark lower-right) and a class-colored title
+// band, with DEFAULT_TITLE as the fallback when no class color is set.
+static const wxColour BACKGROUND_COLOR(232, 232, 232);
+static const wxColour UPPER_DARK_COLOR(240, 240, 240);
+static const wxColour UPPER_LIGHT_COLOR(255, 255, 255);
+static const wxColour LOWER_LIGHT_COLOR(160, 160, 160);
+static const wxColour LOWER_DARK_COLOR(128, 128, 128);
+static const wxColour DEFAULT_TITLE(166, 190, 191);
 static const wxColour TEXT_COLOR(40, 40, 40);
 static const wxColour SELECTED_COLOR(255, 200, 60);
 
@@ -27,6 +34,14 @@ static const wxColour SELECTED_COLOR(255, 200, 60);
 static const REAL MIN_NODE_RADIUS = 8.0f;
 static const REAL MAX_NODE_RADIUS = 80.0f;
 static const REAL ACTIVATION_SCALE = 120.0f;
+
+// Returns true if the given title-band color is "dark enough" that white
+// text reads better than the default dark text color.
+static bool TitleBandIsDark(const wxColour& c)
+{
+    int luma = (299 * c.Red() + 587 * c.Green() + 114 * c.Blue()) / 1000;
+    return luma < 150;
+}
 
 #ifdef USE_OPENGL_RENDERER
 wxBEGIN_EVENT_TABLE(SpacePanel, wxGLCanvas)
@@ -263,7 +278,12 @@ void SpacePanel::OnPaint(wxPaintEvent& event)
     OnPaintGL(event);
 #else
     wxBufferedPaintDC dc(this);
-    dc.SetBackground(wxBrush(*wxWHITE));
+    // Use a slightly lighter shade than the legacy node background so the
+    // BACKGROUND_COLOR-filled node bodies are visually distinct from the
+    // canvas. The legacy MFC view used the same gray for both and relied on
+    // beveled outlines for separation — we keep the bevels but lift the
+    // canvas to near-white for clarity.
+    dc.SetBackground(wxBrush(wxColour(248, 248, 248)));
     dc.Clear();
 
     if (!m_pSpace) {
@@ -443,11 +463,16 @@ void SpacePanel::DrawLink(wxDC& dc, CNode* pFrom, CNode* pTo, REAL weight)
     // Line width based on weight
     int penWidth = std::max(1, (int)(weight * 3.0f));
 
-    // Alpha based on average activation
+    // Brightness based on average activation — strongly activated links
+    // appear darker (closer to LOWER_DARK_COLOR), weak links fade toward the
+    // page background (BACKGROUND_COLOR), mirroring NodeViewSkin::DrawLink.
     REAL avgAct = (itFrom->second.springActivation + itTo->second.springActivation) * 0.5f;
-    int alpha = std::min(255, (int)(avgAct * 500.0f + 30.0f));
+    REAL t = std::min(1.0f, avgAct * 6.0f);
+    int rC = (int)(BACKGROUND_COLOR.Red()   * (1.0f - t) + LOWER_DARK_COLOR.Red()   * t);
+    int gC = (int)(BACKGROUND_COLOR.Green() * (1.0f - t) + LOWER_DARK_COLOR.Green() * t);
+    int bC = (int)(BACKGROUND_COLOR.Blue()  * (1.0f - t) + LOWER_DARK_COLOR.Blue()  * t);
 
-    wxPen pen(wxColour(100, 100, 180, alpha), penWidth);
+    wxPen pen(wxColour(rC, gC, bC), penWidth);
     dc.SetPen(pen);
     dc.DrawLine(ptFrom, ptTo);
 }
@@ -479,100 +504,267 @@ void SpacePanel::DrawNode(wxDC& dc, CNode* pNode, const NodeViewData& viewData)
 
     bool isSelected = (m_pSpace && m_pSpace->GetCurrentNode() == pNode);
 
-    // Compute elliptangle-like shape: blend between ellipse and rounded rect
-    // For simplicity in 2D, use rounded rectangle for high activation, ellipse for low
+    // Outer rectangle for the node (a bit wider than tall, "elliptangle"-ish).
     wxRect nodeRect(center.x - r, center.y - (int)(r * 0.7),
                     r * 2, (int)(r * 1.4));
 
-    // Fill color based on activation
-    wxColour fillColor = ActivationColor(act);
-    dc.SetBrush(wxBrush(fillColor));
-
-    // Border
-    if (isSelected) {
-        dc.SetPen(wxPen(SELECTED_COLOR, 3));
-    } else {
-        // Beveled look: light top-left, dark bottom-right
-        dc.SetPen(wxPen(NODE_BORDER_LIGHT, 2));
-    }
-
-    // Draw the shape
-    if (r > 20) {
-        // Rounded rectangle for larger nodes (like elliptangle)
-        int cornerRadius = std::min(r / 3, 15);
-        dc.DrawRoundedRectangle(nodeRect, cornerRadius);
-
-        // Draw a second border for bevel effect
-        if (!isSelected) {
-            dc.SetPen(wxPen(NODE_BORDER_DARK, 1));
-            wxRect innerRect = nodeRect;
-            innerRect.Deflate(1);
-            dc.SetBrush(*wxTRANSPARENT_BRUSH);
-            dc.DrawRoundedRectangle(innerRect, cornerRadius - 1);
-        }
-    } else {
-        // Ellipse for smaller nodes
+    // For very small nodes fall back to a simple ellipse — the title-band
+    // layout is not legible at that size.
+    if (r <= 20) {
+        wxColour fillColor = ActivationColor(act);
+        dc.SetBrush(wxBrush(fillColor));
+        dc.SetPen(isSelected ? wxPen(SELECTED_COLOR, 2)
+                             : wxPen(LOWER_DARK_COLOR, 1));
         dc.DrawEllipse(nodeRect);
+        return;
     }
 
-    // Draw node name
-    if (r > 15 && pNode->GetName().GetLength() > 0) {
-        dc.SetTextForeground(TEXT_COLOR);
+    int cornerRadius = std::min(r / 3, 15);
 
-        // Scale font size with node size (proportional, no upper cap)
-        int fontSize = std::max(8, r / 3);
-        wxFont font(fontSize, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
-        dc.SetFont(font);
+    // 1. Body: light gray legacy background.
+    dc.SetBrush(wxBrush(BACKGROUND_COLOR));
+    dc.SetPen(*wxTRANSPARENT_PEN);
+    dc.DrawRoundedRectangle(nodeRect, cornerRadius);
 
-        wxString name((const char*)pNode->GetName());
-        wxSize textSize = dc.GetTextExtent(name);
+    // 2. Title band: clipped to the rounded body so the colored band
+    //    sits flush against the upper bevel.
+    int titleHeight = std::max(14, r / 3);
+    if (titleHeight > nodeRect.GetHeight() - 6) {
+        titleHeight = nodeRect.GetHeight() - 6;
+    }
+    wxRect titleRect(nodeRect.GetLeft(), nodeRect.GetTop(),
+                     nodeRect.GetWidth(), titleHeight);
 
-        // Center the text in the node
-        int tx = center.x - textSize.GetWidth() / 2;
-        int ty = center.y - textSize.GetHeight() / 2;
+    wxColour titleColor = ClassColor(pNode);
+    {
+        dc.SetBrush(wxBrush(titleColor));
+        dc.SetPen(*wxTRANSPARENT_PEN);
+        // Clip to the rounded body so the band follows the corners.
+        dc.SetClippingRegion(nodeRect);
+        // Draw a slightly oversized rectangle so it tucks under the bevel.
+        dc.DrawRectangle(titleRect.GetLeft(), titleRect.GetTop(),
+                         titleRect.GetWidth(), titleRect.GetHeight());
+        dc.DestroyClippingRegion();
+    }
 
-        // Clip to node bounds
-        if (textSize.GetWidth() < nodeRect.GetWidth() - 4) {
-            dc.DrawText(name, tx, ty);
-        } else {
-            // Truncate with ellipsis
-            wxString truncated = name;
-            while (truncated.Length() > 1) {
-                truncated = truncated.Left(truncated.Length() - 1);
-                wxSize ts = dc.GetTextExtent(truncated + "...");
-                if (ts.GetWidth() < nodeRect.GetWidth() - 4) {
-                    dc.DrawText(truncated + "...",
-                                center.x - ts.GetWidth() / 2, ty);
-                    break;
+    // 3. Beveled outline: upper-left light highlight, then a darker inset
+    //    rounded rectangle offset down/right for the lower-right shadow,
+    //    mirroring the legacy GDI bevel.
+    dc.SetBrush(*wxTRANSPARENT_BRUSH);
+    dc.SetPen(wxPen(UPPER_LIGHT_COLOR, 1));
+    {
+        wxRect outerHi = nodeRect;
+        outerHi.Deflate(1, 1);
+        dc.DrawRoundedRectangle(outerHi, std::max(0, cornerRadius - 1));
+    }
+    dc.SetPen(wxPen(LOWER_LIGHT_COLOR, 1));
+    {
+        wxRect inner = nodeRect;
+        inner.Deflate(2, 2);
+        inner.x += 1;
+        inner.y += 1;
+        dc.DrawRoundedRectangle(inner, std::max(1, cornerRadius - 2));
+    }
+
+    // 4. Selection / outline pen — drawn last so it sits on top.
+    dc.SetBrush(*wxTRANSPARENT_BRUSH);
+    if (isSelected) {
+        int penWidth = std::max(2, r / 20);
+        dc.SetPen(wxPen(SELECTED_COLOR, penWidth));
+    } else {
+        dc.SetPen(wxPen(LOWER_DARK_COLOR, 1));
+    }
+    dc.DrawRoundedRectangle(nodeRect, cornerRadius);
+
+    // 5. Image (if any) on the left of the body region.
+    wxRect bodyRect(nodeRect.GetLeft() + 3,
+                    titleRect.GetBottom() + 2,
+                    nodeRect.GetWidth() - 6,
+                    nodeRect.GetBottom() - titleRect.GetBottom() - 4);
+
+    auto& mutableNV = m_nodeViews[pNode];
+    if (EnsureNodeImage(pNode, mutableNV) && bodyRect.GetHeight() > 8) {
+        const wxBitmap& bmp = mutableNV.image;
+        if (bmp.IsOk()) {
+            // Fit image into a square area on the left of the body, preserving
+            // aspect ratio.
+            int targetH = bodyRect.GetHeight() - 2;
+            int targetW = std::min(targetH, bodyRect.GetWidth() / 2);
+            if (targetW > 4 && targetH > 4) {
+                wxImage img = bmp.ConvertToImage();
+                int srcW = img.GetWidth();
+                int srcH = img.GetHeight();
+                // Preserve aspect ratio inside (targetW x targetH).
+                int drawW = targetW;
+                int drawH = targetH;
+                if (srcW > 0 && srcH > 0) {
+                    double sa = (double)srcW / (double)srcH;
+                    double ta = (double)targetW / (double)targetH;
+                    if (sa > ta) {
+                        drawH = (int)(targetW / sa);
+                    } else {
+                        drawW = (int)(targetH * sa);
+                    }
                 }
+                if (drawW < 1) drawW = 1;
+                if (drawH < 1) drawH = 1;
+                wxImage scaled = img.Scale(drawW, drawH, wxIMAGE_QUALITY_NORMAL);
+                wxBitmap scaledBmp(scaled);
+                int ix = bodyRect.GetLeft() + (targetW - drawW) / 2;
+                int iy = bodyRect.GetTop() + (targetH - drawH) / 2;
+                dc.DrawBitmap(scaledBmp, ix, iy, true);
+                // Shrink body region so text starts to the right of the image.
+                bodyRect.x += targetW + 4;
+                bodyRect.width -= targetW + 4;
             }
         }
     }
 
-    // Draw description text for sufficiently activated nodes
-    if (r > 30 && act > 0.08f && pNode->GetDescription().GetLength() > 0) {
-        int descFontSize = std::max(7, r / 4);
+    // 6. Title text inside the title band.
+    if (pNode->GetName().GetLength() > 0 && titleRect.GetHeight() > 8) {
+        int fontSize = std::max(8, titleHeight - 6);
+        wxFont font(fontSize, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL,
+                    wxFONTWEIGHT_BOLD);
+        dc.SetFont(font);
+        dc.SetTextForeground(TitleBandIsDark(titleColor)
+                             ? wxColour(255, 255, 255)
+                             : TEXT_COLOR);
+
+        wxString name((const char*)pNode->GetName());
+
+        // Truncate with ellipsis to fit the title band.
+        int avail = titleRect.GetWidth() - 8;
+        wxString display = name;
+        wxSize ts = dc.GetTextExtent(display);
+        while (ts.GetWidth() > avail && display.Length() > 1) {
+            display = display.Left(display.Length() - 1);
+            ts = dc.GetTextExtent(display + "...");
+            if (ts.GetWidth() <= avail) {
+                display += "...";
+                break;
+            }
+        }
+
+        dc.SetClippingRegion(titleRect);
+        int tx = titleRect.GetLeft() + 4;
+        int ty = titleRect.GetTop() + (titleRect.GetHeight() - ts.GetHeight()) / 2;
+        dc.DrawText(display, tx, ty);
+        dc.DestroyClippingRegion();
+    }
+
+    // 7. Description text in the body region (skipping over the image, if any).
+    if (bodyRect.GetHeight() > 10 && bodyRect.GetWidth() > 10 &&
+        pNode->GetDescription().GetLength() > 0)
+    {
+        int descFontSize = std::max(7, r / 5);
         wxFont descFont(descFontSize, wxFONTFAMILY_SWISS,
                         wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
         dc.SetFont(descFont);
-        dc.SetTextForeground(wxColour(100, 100, 100));
+        dc.SetTextForeground(TEXT_COLOR);
 
         wxString desc((const char*)pNode->GetDescription());
 
-        // Position below the name
-        int descTop = center.y + 2;
-        int descWidth = nodeRect.GetWidth() - 8;
-        int descLeft = center.x - descWidth / 2;
+        dc.SetClippingRegion(bodyRect);
+        // Simple word-wrap: emit space-delimited words on as many lines as fit.
+        int yCursor = bodyRect.GetTop();
+        int lineHeight = dc.GetCharHeight();
+        wxString line;
+        size_t i = 0;
+        while (i <= desc.length() && yCursor + lineHeight <= bodyRect.GetBottom()) {
+            bool atEnd = (i == desc.length());
+            wxChar ch = atEnd ? wxT('\n') : desc[i];
+            if (ch == wxT('\n') || ch == wxT('\r') || ch == wxT(' ') || atEnd) {
+                if (ch == wxT('\n') || ch == wxT('\r')) {
+                    dc.DrawText(line, bodyRect.GetLeft(), yCursor);
+                    yCursor += lineHeight;
+                    line.Clear();
+                } else {
+                    // word boundary
+                    size_t j = i;
+                    while (j < desc.length() && desc[j] != wxT(' ') &&
+                           desc[j] != wxT('\n') && desc[j] != wxT('\r')) {
+                        j++;
+                    }
+                    wxString word = desc.SubString(i, j - 1);
+                    wxString trial = line.empty() ? word : (line + wxT(' ') + word);
+                    if (dc.GetTextExtent(trial).GetWidth() <= bodyRect.GetWidth()) {
+                        line = trial;
+                    } else {
+                        if (!line.empty()) {
+                            dc.DrawText(line, bodyRect.GetLeft(), yCursor);
+                            yCursor += lineHeight;
+                        }
+                        line = word;
+                    }
+                    i = j;
+                    continue;
+                }
+            }
+            i++;
+        }
+        if (!line.empty() && yCursor + lineHeight <= bodyRect.GetBottom()) {
+            dc.DrawText(line, bodyRect.GetLeft(), yCursor);
+        }
+        dc.DestroyClippingRegion();
+    }
+}
 
-        wxRect descRect(descLeft, descTop, descWidth,
-                        nodeRect.GetBottom() - descTop - 4);
+bool SpacePanel::EnsureNodeImage(CNode* pNode, NodeViewData& viewData)
+{
+    wxString filename((const char*)pNode->GetImageFilename());
 
-        if (descRect.GetHeight() > descFontSize + 2) {
-            dc.SetClippingRegion(descRect);
-            dc.DrawText(desc, descRect.GetLeft(), descRect.GetTop());
-            dc.DestroyClippingRegion();
+    if (filename.IsEmpty()) {
+        // No image set; nothing to load.
+        viewData.image = wxBitmap();
+        viewData.loadedImageFilename.Clear();
+        viewData.imageLoadAttempted = true;
+        return false;
+    }
+
+    // If we already attempted to load this exact filename, return cached result.
+    if (viewData.imageLoadAttempted && viewData.loadedImageFilename == filename) {
+        return viewData.image.IsOk();
+    }
+
+    viewData.imageLoadAttempted = true;
+    viewData.loadedImageFilename = filename;
+    viewData.image = wxBitmap();
+
+    // Build a list of candidate paths to try. Mirrors the MFC version's
+    // <space-path-dir>/images/<filename> convention plus some saner fallbacks.
+    wxArrayString candidates;
+    candidates.Add(filename);
+
+    if (m_pSpace) {
+        wxString spacePath((const char*)m_pSpace->GetPathName());
+        if (!spacePath.IsEmpty()) {
+            wxFileName fn(spacePath);
+            wxString dir = fn.GetPath();
+            if (!dir.IsEmpty()) {
+                candidates.Add(dir + wxFileName::GetPathSeparator()
+                               + "images" + wxFileName::GetPathSeparator()
+                               + filename);
+                candidates.Add(dir + wxFileName::GetPathSeparator() + filename);
+            }
         }
     }
+
+    candidates.Add("images" + wxString(wxFileName::GetPathSeparator()) + filename);
+    candidates.Add("data" + wxString(wxFileName::GetPathSeparator())
+                   + "images" + wxString(wxFileName::GetPathSeparator())
+                   + filename);
+
+    for (size_t i = 0; i < candidates.GetCount(); i++) {
+        const wxString& path = candidates[i];
+        if (!wxFileName::FileExists(path)) continue;
+        wxImage img;
+        if (img.LoadFile(path)) {
+            viewData.image = wxBitmap(img);
+            return viewData.image.IsOk();
+        }
+    }
+
+    return false;
 }
 
 #ifdef USE_OPENGL_RENDERER

--- a/src/theWheelWx/SpacePanel.h
+++ b/src/theWheelWx/SpacePanel.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <wx/wx.h>
+#include <wx/bitmap.h>
 #ifdef USE_OPENGL_RENDERER
 #include <wx/glcanvas.h>
 #include <GLRenderer.h>
@@ -31,8 +32,16 @@ struct NodeViewData
     Spring1D activationSpring;
     REAL springActivation;
 
+    // Cached node image (loaded lazily from CNode::GetImageFilename()).
+    // imageLoadAttempted is true once we've tried; image.IsOk() tells us
+    // whether the load succeeded.
+    wxBitmap image;
+    wxString loadedImageFilename;
+    bool imageLoadAttempted;
+
     NodeViewData()
         : springActivation(0.0f)
+        , imageLoadAttempted(false)
     {
         positionSpring.SetK(3.0f);
         positionSpring.SetB(10.0f);
@@ -94,6 +103,10 @@ private:
     // Color helpers
     wxColour ActivationColor(REAL activation) const;
     wxColour ClassColor(CNode* pNode) const;
+
+    // Lazily load the image referenced by pNode->GetImageFilename() into
+    // viewData.image. Returns true if a usable bitmap is available.
+    bool EnsureNodeImage(CNode* pNode, NodeViewData& viewData);
 
     CSpace* m_pSpace;
     SpaceTreeView* m_pTreeView;

--- a/src/theWheelWx/SpaceSerializer.cpp
+++ b/src/theWheelWx/SpaceSerializer.cpp
@@ -129,9 +129,21 @@ void SpaceSerializer::CreateSampleSpace(CSpace* pSpace)
     CNode* pRoot = pSpace->GetRootNode();
     if (!pRoot) return;
 
-    // The CreateSimpleSpace already creates nodes - let's set some positions
-    // for a nice initial layout
+    // Seed the class-color map with a few legacy theWheel colors so the
+    // title bands on sample nodes render in distinct colors.
+    auto& colorMap = pSpace->GetClassColorMap();
+    colorMap["Concept"] = RGB(166, 190, 191);  // DEFAULT_TITLE
+    colorMap["Process"] = RGB(190, 165, 140);  // warm sand
+    colorMap["Module"]  = RGB(140, 165, 190);  // cool slate
+    colorMap["Goal"]    = RGB(180, 150, 165);  // mauve
+
+    // Cycle the three classes across non-root nodes so they get colored
+    // title bands by default.
+    static const char* kClasses[] = { "Concept", "Process", "Module", "Goal" };
+    int classCount = (int)(sizeof(kClasses) / sizeof(kClasses[0]));
+
     srand(42);
+    int assignIdx = 0;
     for (int i = 0; i < pSpace->GetNodeCount(); i++) {
         CNode* pNode = pSpace->GetNodeAt(i);
         CVectorD<3> pos;
@@ -141,5 +153,12 @@ void SpaceSerializer::CreateSampleSpace(CSpace* pSpace)
         pos[1] = radius * sin(angle);
         pos[2] = R(0.0);
         pNode->SetPosition(pos);
+
+        // Skip the hidden root and the visible root; assign classes to the
+        // remaining nodes so the title bands are visually distinct.
+        CString name = pNode->GetName();
+        if (name == "%%hiddenroot%%" || name == "root") continue;
+        pNode->SetClass(kClasses[assignIdx % classCount]);
+        assignIdx++;
     }
 }

--- a/src/theWheelWx/WheelApp.cpp
+++ b/src/theWheelWx/WheelApp.cpp
@@ -11,6 +11,7 @@
 #include "SpaceSerializer.h"
 #include "PropertyDialogs.h"
 #include <SpaceLayoutManager.h>
+#include <wx/image.h>
 
 #ifndef THEWHEEL_WX_TESTING
 wxIMPLEMENT_APP(WheelApp);
@@ -18,6 +19,10 @@ wxIMPLEMENT_APP(WheelApp);
 
 bool WheelApp::OnInit()
 {
+    // Enable PNG/JPG/GIF/BMP decoders so CNode::GetImageFilename() can be
+    // rendered into each node's image area.
+    wxInitAllImageHandlers();
+
     WheelFrame* frame = new WheelFrame();
     frame->Show(true);
     return true;


### PR DESCRIPTION
Replace the wxWidgets node renderer with a layout closer to the
legacy theWheel skin: a light-gray rounded body with a beveled
outline, a class-colored title band across the top, and a slot
on the left of the body for the node's image (loaded from
CNode::GetImageFilename() via wxImage).

Colors come straight from NodeViewSkin.cpp / NodeView.cpp
(BACKGROUND_COLOR, UPPER_LIGHT/DARK, LOWER_LIGHT/DARK,
DEFAULT_TITLE), and class colors come from
CSpace::GetClassColorMap() — same fallback chain as the legacy
MFC view.

Also:
- WheelApp calls wxInitAllImageHandlers so PNG/JPG node images
  decode at runtime.
- CreateSampleSpace seeds a few class colors so the new title
  bands are visible out of the box.
- mfc_compat.h now includes <cstdarg> so CString::Format builds
  on Linux/GCC (was a pre-existing latent issue).